### PR TITLE
FIX #64: Fix dropping of effects by detecting if an effect is already scheduled.

### DIFF
--- a/modules/effects.js
+++ b/modules/effects.js
@@ -53,6 +53,15 @@ export function isEffect(object) {
 }
 
 /**
+ * Determines id the effect object is of type none
+ * @param {Object} The object to inspect.
+ * @returns {Boolean} Whether the object is a none effect.
+ */
+export function isNone(object) {
+  return object ? object.type === effectTypes.NONE : false;
+}
+
+/**
  * Creates a noop effect.
  * @returns {Object} An effect of type NONE, essentially a no-op.
  */

--- a/modules/install.js
+++ b/modules/install.js
@@ -13,6 +13,7 @@ import {
   batch,
   none,
   isEffect,
+  isNone,
   effectToPromise,
 } from './effects';
 
@@ -28,7 +29,11 @@ export function install() {
     const liftReducer = (reducer) => (state, action) => {
       const result = reducer(state, action);
       const [model, effect] = liftState(result);
-      currentEffect = effect;
+      if (isNone(currentEffect)) {
+        currentEffect = effect
+      } else {
+        currentEffect = batch([currentEffect, effect]);
+      }
       return model;
     };
 


### PR DESCRIPTION
This is a potential fix to the issue #64.

There is a test that simulates the behaviour specified in #64 where an action causes an effect, and a store subscriber (e.g. react redux) ends up triggering a component hook which dispatches another action, resulting in the original effect being clobbered with a `NONE` effect.

Please let me know of any improvements I can make to this PR!
