### PR TITLE
Add support for nested loops

### DIFF
--- a/modules/loop.js
+++ b/modules/loop.js
@@ -1,5 +1,5 @@
 import { throwInvariant } from './utils';
-import { isEffect, none } from './effects';
+import { isEffect, none, batch } from './effects';
 
 
 /**
@@ -34,7 +34,8 @@ export const getModel = (loop) => {
 }
 
 /**
- * Attaches an effect to the model.
+ * Attaches an effect to the model if a model is passed,
+ * or batches the effects of the loop if a loop is passed
  *
  *   function reducerWithSingleEffect(state, action) {
  *     // ...
@@ -55,7 +56,7 @@ export const getModel = (loop) => {
  *     );
  *   }
  */
-export const loop = (model, effect) => {
+export const loop = (loopOrModel, effect) => {
   if(process.env.NODE_ENV === 'development') {
     throwInvariant(
       isEffect(effect),
@@ -63,7 +64,11 @@ export const loop = (model, effect) => {
     );
   }
 
-  return [model, effect];
+  if (!isLoop(loopOrModel)) {
+    return [loopOrModel, effect];
+  }
+  const batchedEffect = batch([getEffect(loopOrModel), effect]);
+  return [getModel(loopOrModel), batchedEffect];
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -170,3 +170,23 @@ test('Effects.call', (t) => {
       t.end();
     });
 });
+
+test('Looping a loop batches the effects together', (t) => {
+  const innerEffect = Effects.constant({ type: 'INNER', name: 'inner'});
+  const outerEffect = Effects.constant({ type: 'OUTER', name: 'outer'});
+
+  const innerLoop = loop({state: 'model'}, innerEffect);
+  const outerLoop = loop(innerLoop, outerEffect);
+
+  t.deepEqual(outerLoop[0], {state: 'model'}, 'the model is unchanged');
+
+  effectToPromise(outerLoop[1])
+    .then((actions) => {
+      t.deepEqual(
+        actions,
+        [{ type: 'INNER', name: 'inner'}, { type: 'OUTER', name: 'outer'}],
+        'the actions are batched together'
+      );
+      t.end();
+    });
+})


### PR DESCRIPTION
It would be helpful for `loop` to be agnostic of whether it's passed a loop or a model, to allow composable looped state transitions. This seems to be in line with the style of the rest of the API.  

```
const DoTheThing = (state) => loop(state, Effect1);
const DoTheOtherThing = (state) => loop(state, Effect2);

// such that the following useless reducer would be legal and batch the effects
const reducer = (state, action) => DoTheThing(DoTheOtherThing(state))
```