### PR TITLE
enhance combineReducers()

### DIFF
--- a/modules/combineReducers.js
+++ b/modules/combineReducers.js
@@ -23,20 +23,27 @@ const defaultMutator = (state, key, value) => {
   };
 };
 
+const keys = (value) => {
+  return [
+    ...Object.getOwnPropertyNames(value),
+    ...Object.getOwnPropertySymbols(value)
+  ];
+};
+
 export function combineReducers(
     reducerMap,
     rootState = {},
     accessor = defaultAccessor,
     mutator = defaultMutator
 ) {
-    return function finalReducer(state = rootState, action) {
+    return function finalReducer(state = rootState, action, ...rest) {
         let hasChanged = false;
         let effects = [];
 
-        const model = Object.keys(reducerMap).reduce((model, key) => {
+        const model = keys(reducerMap).reduce((model, key) => {
             const reducer = reducerMap[key];
             const previousStateForKey = accessor(state, key);
-            let nextStateForKey = reducer(previousStateForKey, action);
+            let nextStateForKey = reducer(previousStateForKey, action, ...rest);
 
             if (isLoop(nextStateForKey)) {
                 effects.push(getEffect(nextStateForKey));


### PR DESCRIPTION
There are a couple of features that I need from `combineReducers()`.
* support reducers with `Symbol` keys
* pass additional arguments to reducers

If these enhancements are generally a good thing then please consider my pull request.

I do see that there is a branch to remove `combineReducers()` so this PR may be uninformed. If so please let me know what the near-future plans are and let me know if I can help.