### PR TITLE
remove `babel` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "babel": "6.3.13",
     "babel-cli": "6.3.17",
     "babel-plugin-transform-es3-member-expression-literals": "6.3.13",
     "babel-plugin-transform-es3-property-literals": "6.3.13",


### PR DESCRIPTION
not a big deal but `babel` as a package currently doesn't actually run anything after babel 6 (it's in babel-cli which is a dependency already)

https://github.com/babel/babel/blob/master/packages/babel/cli.js