### PR TITLE
Fixes liftState and compose example.

### DIFF
--- a/docs/ApiDocs.md
+++ b/docs/ApiDocs.md
@@ -142,7 +142,9 @@ function reducer(state, action) {
 // regardless of if it was set as such in the reducer implementation. This makes
 // it much easier to manually compose reducers without cluttering reducer
 // implementations with `loop(state, Effects.none())`.
-export default compose(reducer, liftState);
+// The rightmost function defines the signature for the resulting composition.
+// https://github.com/reactjs/redux/blob/master/src/compose.js
+export default compose(liftState, reducer);
 ```
 
 


### PR DESCRIPTION
Hey,

I think when using `compose` from `redux` and `liftState`, we should make sure `reducer` is the rightmost function to maintain the `(state, action)` signature.

https://github.com/reactjs/redux/blob/master/src/compose.js#L1:L10

Thanks!