### PR TITLE
add transform runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
   "plugins": [
     "transform-object-rest-spread",
     "transform-es3-member-expression-literals",
-    "transform-es3-property-literals"
+    "transform-es3-property-literals",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -47,15 +47,14 @@
     "email": "opensource@lukewestby.com",
     "url": "https://twitter.com/luke_dot_js"
   },
-  "contributors": [
-
-  ],
+  "contributors": [],
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "6.3.17",
     "babel-plugin-transform-es3-member-expression-literals": "6.3.13",
     "babel-plugin-transform-es3-property-literals": "6.3.13",
     "babel-plugin-transform-object-rest-spread": "6.3.13",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "6.7.2",
     "babel-preset-es2015": "6.3.13",
     "babel-register": "6.7.2",
@@ -63,5 +62,8 @@
     "redux": "3.6.0",
     "rimraf": "2.4.4",
     "tape": "4.5.1"
+  },
+  "dependencies": {
+    "babel-runtime": "^6.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "babel modules --out-dir lib",
-    "test": "tape -r babel-polyfill -r babel-register './test/*.test.js'",
+    "test": "tape -r babel-register './test/*.test.js'",
     "prepublish": "npm run clean && npm run build"
   },
   "keywords": [
@@ -55,7 +55,6 @@
     "babel-plugin-transform-es3-property-literals": "6.3.13",
     "babel-plugin-transform-object-rest-spread": "6.3.13",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "6.7.2",
     "babel-preset-es2015": "6.3.13",
     "babel-register": "6.7.2",
     "immutable": "3.7.6",


### PR DESCRIPTION
I've been wanting to convert my company's codebase to stop using polyfill, saving some bandwidth, however for IE11, I run into error regarding Symbol being undefined from redux-loop.

This PR makes redux loop use transform which should be best practice for a library.

see https://babeljs.io/docs/plugins/transform-runtime/

> Another purpose of this transformer is to create a sandboxed environment for your code. If you use babel-polyfill and the built-ins it provides such as Promise, Set and Map, those will pollute the global scope. While this might be ok for an app or a command line tool, **it becomes a problem if your code is a library which you intend to publish for others to use or if you can’t exactly control the environment in which your code will run.**

