### PR TITLE
Invalid return value in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ function reducer(state, action) {
       };
 
     default:
-      return state;
+      return {
+        state
+      };
     }
 }
 


### PR DESCRIPTION
I'm not certain if I'm being correct, but it seems that the reducer in the example should return the state under the state key, not just the state by itself.