### PR TITLE
add backwards compatible effects until next major version

### DIFF
--- a/modules/cmd.js
+++ b/modules/cmd.js
@@ -88,7 +88,9 @@ export const cmdToPromise = (cmd, dispatch, getState) => {
     case cmdTypes.MAP:
       const possiblePromise = cmdToPromise(cmd.nestedCmd, dispatch, getState)
       if (!possiblePromise) return null
-      return possiblePromise.then((actions) => actions.map(cmd.tagger))
+      return possiblePromise.then((actions) => 
+        actions.map(action => cmd.tagger(...cmd.args, action))
+      );
 
     /*case cmdTypes.CALLBACK:
       return promisify(cmd.nodeStyleFunction)(...getMappedCmdArgs(cmd.args, dispatch, getState))
@@ -97,6 +99,10 @@ export const cmdToPromise = (cmd, dispatch, getState) => {
         .then((action) => [action])*/
 
     case cmdTypes.NONE:
+      if(cmd.isEffect){
+          console.warn(`Effects.none is deprecated and has been renamed Cmd.none. 
+            Effects.none will be removed in the next major version.`)
+      }
       return null
   }
 }
@@ -267,12 +273,13 @@ const sequence = (cmds) => {
 
 const map = (
   nestedCmd,
-  tagger
+  tagger,
+  ...args
 ) => {
   if (process.env.NODE_ENV !== 'production') {
     throwInvariant(
       isCmd(nestedCmd),
-      'Cmd.map: first argument to Cmd.map must be a function that returns a promise'
+      'Cmd.map: first argument to Cmd.map must be another Cmd'
     )
 
     throwInvariant(
@@ -286,6 +293,7 @@ const map = (
     type: cmdTypes.MAP,
     tagger,
     nestedCmd,
+    args
   })
 }
 

--- a/modules/effects.js
+++ b/modules/effects.js
@@ -1,0 +1,103 @@
+import Cmd from './cmd';
+import { throwInvariant } from './utils';
+
+const promise = (
+  promiseFactory,
+  ...args
+) => {
+  console.warn(`Effects.promise is deprecated. Please
+    use Cmd.run (https://github.com/redux-loop/redux-loop/blob/master/docs/ApiDocs.md#cmdrunfunc-options).
+    Effects.promise will be removed in the next major version.`)
+  if (process.env.NODE_ENV !== 'production') {
+    throwInvariant(
+      typeof promiseFactory === 'function',
+      'Effects.promise: first argument to Effects.promise must be a function that returns a promise'
+    )
+  }
+
+  return Cmd.run(promiseFactory, {
+    successActionCreator: action => action,
+    failActionCreator: action => action,
+    args
+  })
+}
+
+
+const call = (
+  resultFactory,
+  ...args
+) => {
+  console.warn(`Effects.call is deprecated. Please
+    use Cmd.run (https://github.com/redux-loop/redux-loop/blob/master/docs/ApiDocs.md#cmdrunfunc-options).
+    Effects.call will be removed in the next major version.`)
+  if (process.env.NODE_ENV !== 'production') {
+    throwInvariant(
+      typeof resultFactory === 'function',
+      'Effects.call: first argument to Effects.call must be a function'
+    )
+  }
+
+  return Cmd.run(resultFactory, {
+    successActionCreator: action => action,
+    args
+  })
+}
+
+const constant = (actionToDispatch) => {
+  console.warn(`Effects.constant is deprecated and has been renamed Cmd.action. 
+    Effects.constant will be removed in the next major version.`)
+  if (process.env.NODE_ENV !== 'production') {
+    throwInvariant(
+      typeof actionToDispatch === 'object' && actionToDispatch !== null && typeof actionToDispatch.type !== 'undefined',
+      'Effects.constant: first argument and only argument to Cmd.constant must be an action'
+    )
+  }
+  return Cmd.action(actionToDispatch)
+}
+
+const batch = (cmds) => {
+  console.warn(`Effects.batch is deprecated and has been renamed Cmd.batch. 
+    Effects.batch will be removed in the next major version.`)
+  if (process.env.NODE_ENV !== 'production') {
+    throwInvariant(
+      Array.isArray(cmds) && cmds.every(isCmd),
+      'Effects.batch: first and only argument to Effects.batch must be an array of other Cmds/Effects'
+    )
+  }
+
+  return Cmd.batch(cmds)
+}
+
+const lift = (
+  nestedCmd,
+  tagger,
+  args
+) => {
+  console.warn(`Effects.lift is deprecated and has been renamed Cmd.map. 
+    Effects.lift will be removed in the next major version.`)
+  if (process.env.NODE_ENV !== 'production') {
+    throwInvariant(
+      isCmd(nestedCmd),
+      'Effects.lift: first argument to Effects.lift must be another Cmd'
+    )
+
+    throwInvariant(
+      typeof tagger === 'function',
+      'Effects.lift: second argument to Effects.lift must be a function that returns an action'
+    )
+  }
+
+  return Cmd.map(nestedCmd, tagger, ...args)
+}
+ 
+
+const none = {...Cmd.none, isEffect: true}
+
+export default {
+  promise,
+  call,
+  constant,
+  batch,
+  lift,
+  none
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -16,9 +16,12 @@ import {
   combineReducers,
 } from './combineReducers';
 
+import Effects from './effects';
+
 export {
   combineReducers,
   Cmd,
+  Effects,
   install,
   loop,
   liftState,

--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
     "redux": "3.5.2",
     "rimraf": "2.4.4",
     "tape": "4.5.1"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
these will make it easier for people to transition to the new Cmd style api slowly rather than all at once. We should keep them around until version 4.0.

I didn't think it was worth adding the other deprecated effects because they were all just renamed and so it was just find/replace to update them to the new api.