### PR TITLE
Improved TypeScript type definitions for combineReducers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,13 +93,13 @@ declare class Cmd {
   ) => SequenceCmd<A>;
 }
 
-export interface ReducerMapObject<T, A extends Action> {
-  [key: string]: LoopReducer<T, A>;
+export type ReducerMapObject<S, A extends Action = AnyAction> = {
+  [K in keyof S]: LoopReducer<S[K], A>;
 }
 
-declare function combineReducers<S, T>(
-  reducers: ReducerMapObject<T, AnyAction>
-): LiftedLoopReducer<S, AnyAction>;
+declare function combineReducers<S, A extends Action = AnyAction>(
+  reducers: ReducerMapObject<S, A>
+): LiftedLoopReducer<S, A>;
 
 declare function liftState<S, A extends Action>(
   state: S | Loop<S, A>

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -94,11 +94,9 @@ type RootState = {
   counter: CounterState;
 };
 
-type SubStates = TodoState | CounterState;
+type RootAction = TodoActions | CounterActions;
 
-type SubActions = TodoActions | CounterActions;
-
-const rootReducer = combineReducers<RootState, SubStates>({
+const rootReducer = combineReducers<RootState, RootAction>({
   todos: todosReducer,
   counter: counterReducer
 });


### PR DESCRIPTION
Fixes #145 

Removes requirement to specify a union of all sub stores when using combine reducers. Adds a new type parameter to enforce Action types.

## Example

```typescript
interface AppState {
    foo: FooState;
    bar: BarState;
}

interface FooState {
    foo: string;
}

interface BarState {
    bar: string;
}
```

### Current Definitions

```typescript
type SubStores = FooState | BarState;

combineReducers<AppState, SubStores>({
  foo: reduceFoo,
  bar: reduceBar
});
```

### New Definitions

```typescript
// can be used with 1 type parameter, like plain redux
combineReducers<AppState>({
  foo: reduceFoo,
  bar: reduceBar
});

// can be used with 2 type parameters, mirroring the Loop type
type AppAction = FooAction | BarAction;

combineReducers<AppState, AppAction>({
  foo: reduceFoo,
  bar: reduceBar
});
```

## Benefits

The new type definition can be used in a fashion that is identical to someone using redux's own `combineReducers` method with typescript.

```typescript
// redux's combineReducers type definition, takes 1 type parameter (the store interface)
export interface ReducersMapObject { [key: string]: Reducer<any>; }
export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;

// In redux's next branch, they've updated combineReducers to use a mapped type
// But it still only takes 1 type parameter: the store interface
export type ReducersMapObject<S> = { [K in keyof S]: Reducer<S[K]>; }
export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;

// As a result, our definition can now be used in the same fashion.

// Redux 3.x
combineReducers<AppState>({ ... })

// Redux 4.x
combineReducers<AppState>({ ... })

// redux-loop
combineReducers<AppState>({ ... })
```

The second optional action parameter of the new definition keep consistency with the `Loop` type definition. This of course also add more type checking for greater type safety. Trying to combine a reducer with an invalid action type will cause a compile time error.

```typescript
// making a redux-loop reducer, 2 parameters: store and action
function (state: FooState, action: FooAction): FooState | Loop<FooState, FooAction> {
	// ...
}

// combining reducers with redux-loop, 2 parameters: store and action
combineReducers<AppState, AppAction>({
  foo: reduceFoo,
  bar: reduceBar
});
```