### PR TITLE
add mergeChildReducers and deprecate custom combineReducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ the result. There are several options for cmds, all available under the `Cmd` ob
 - `run(functionToCall, options)`
   - Accepts a function to run and options for how to call it and what to do with the result.
 - `action(actionToDispatch)`
-  - Accepts an `actionToDispatch` instance to dispatch immediately once the current dispatch cycle is completed.
+  - Accepts an action to dispatch immediately once the current dispatch cycle is completed.
 - `list(cmds, options)`
   - Accepts an array of other cmds and runs them. Options control whether they run in parallel or in order, and when to dispatch the resulting actions.
 - `map(cmd, higherOrderActionCreator, ...args)`
@@ -222,64 +222,6 @@ state and always get a result which is `deepEqual`.
 > not equal within JavaScript, and so are best to avoid if you want to compare
 > effects in your tests.
 
-### combineReducers with redux-loop
-
-```js
-import { createStore } from 'redux';
-import { combineReducers, install } from 'redux-loop';
-
-import { firstReducer, secondReducer } from './reducers';
-
-const reducer = combineReducers({
-  first: firstReducer,
-  second: secondReducer,
-});
-
-const store = createStore(reducer, initialState, install());
-```
-
-The `combineReducers` implementation in `redux-loop` is aware that some of
-your reducers might return cmds, and it knows how to properly compose them
-and forward them to the store. 
-
-#### How to use combineReducers when using libraries such as immutable.js
-
-Our `combineReducers` can also handle states made of data structures
-other than the default `{}`, you simply pass it in the root state,
-an accessor function (which returns a value for that key), and a mutator
-function (which returns a **new version** of the object with a value
-set at a given key). The example below demonstrates using Immutable.js'
-Map() data structure, but you can use any `key => value` data structure
-as long as you provide your own accessor and mutator functions.
-
-While these customization features are provided for convenience, if you
-are using using something other than a plain object as your state, you should
-consider writing your own implementation of combineReducers, using our 
-version as a reference. It's impossible to provide a generic combineReducers
-that will be optimal for all state shapes. As an example, updating an immutable.js
-state would be much faster if you made use of the withMutations method to run updates. 
-
-```js
-import { combineReducers } from 'redux-loop';
-import { Map } from 'immutable';
-
-import { firstReducer, secondReducer } from './reducers';
-
-const reducers = {
-  first: firstReducer,
-  second: secondReducer,
-}
-
-//Map() is now used as the new root state, and custom accessor and mutator properties are provided
-const reducer = combineReducers(
-    reducers,
-    Map(),
-    (child, key) => child.get(key),
-    (child, key, value) => child.set(key, value)
-);
-
-```
-
 ### Avoid circular loops!
 
 ```js
@@ -307,6 +249,77 @@ keep your reducers small and focused, and use `combineReducers` or manually
 compose reducers so that the number of actions you deal with at one time is
 small. A small set of actions which initiate a `loop` will help reduce the
 likelihood of causing circular dispatches.
+
+### combineReducers with redux-loop
+
+```js
+import { createStore } from 'redux';
+import { combineReducers, install } from 'redux-loop';
+
+import { firstReducer, secondReducer } from './reducers';
+
+const reducer = combineReducers({
+  first: firstReducer,
+  second: secondReducer,
+});
+
+const store = createStore(reducer, initialState, install());
+```
+
+The `combineReducers` implementation in `redux-loop` is aware that some of
+your reducers might return cmds, and it knows how to properly compose them
+and forward them to the store. 
+
+### How to nest reducers inside parents with their own functionality
+
+`combineReducers` is great for the case where your parent reducer has no functionality of its own, just children.
+However, it's often the case that you want to nest a specific reducer inside a generic parent reducer.
+
+`mergeChildReducers` lets you do this. It merges child reducer state into the parent state while
+composing any Cmds returned by any of the reducers and passing them along to the store.
+
+```js
+
+const initialState = {foo: null};
+
+function parentReducer(state = initialState, action){
+  //typical reducer
+}
+
+export default function reducer(state, action){
+   let parentResult = parentReducer(state, action);
+   return mergeChildReducers(parentResult, action, {child: childReducer});
+}
+
+//final state shape is {foo, child}; foo.child is state returned by childReducer
+```
+
+`combineReducers` just returns a reducer with a specific usage of `mergeChildReducers` (one in which
+the child map never changes, the parent state is an empty object, and all children always get called). 
+By using `mergeChildReducers` in your reducer, you can choose which children are used when and under what key names.
+
+By using `combineReducers` or `mergeChildReducers` everywhere your reducer tree nests, all Cmds resulting 
+from a single dispatched action will always be batched up into a single Cmd at the top of the tree and 
+processed correctly by the store. 
+
+### How to use `combineReducers` and `mergeChildReducers` with ImmutableJS and other libraries
+
+It's impossible to write a version of `combineReducers` or `mergeChildReducers` that supports all use cases well.
+You may want your parent state to be an array or you may be using a library such as ImmutableJS with non-standard data structures. [Like redux's implementation of combineReducers](http://redux.js.org/docs/recipes/reducers/BeyondCombineReducers.html), redux-loop's are designed to only work with plain JS objects.
+Certain implementations may be generic enough to handle many use cases, but chances are that they will be
+sub-optimal in most scenarios. For example, when iterating over properties of an Immutable Map to update children,
+unless you use withMutations, you will create a new parent object for each key that you iterate over and will
+have worse performance.
+
+For this reason, we have broken out integrations with popular libraries into separate packages.
+
+- [ImmutableJS](https://github.com/redux-loop/redux-loop-immutable)
+
+If your use case is not currently supported, we encourage you to write your own helpers to compose reducers that
+fit your specific needs. The only requirement for redux-loop is that they pull the commands out of the child results and batch them together into a single Cmd to be passed along in the resulting loop object.
+See the [mergeChildReducers](src/merge-child-reducers.js) and [combineReducers](src/combineReducers.js) implementations for reference.
+
+If you have a popular use case or library that is not currently supported, please file an issue and we can discuss if it makes sense for us to support a custom integration. 
 
 ## Support
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,12 @@ declare function combineReducers<S, A extends Action = AnyAction>(
   reducers: ReducerMapObject<S, A>
 ): LiftedLoopReducer<S, A>;
 
+declare function mergeChildReducers<S, A extends Action = AnyAction>(
+  parentResult: S | Loop<S, A>,
+  action: AnyAction,
+  childMap: ReducerMapObject<S, A>
+): Loop<S, A>;
+
 declare function liftState<S, A extends Action>(
   state: S | Loop<S, A>
 ): Loop<S, A>;

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,11 @@ import {
   combineReducers,
 } from './combineReducers';
 
+import mergeChildReducers from './merge-child-reducers';
+
 export {
   combineReducers,
+  mergeChildReducers,
   Cmd,
   install,
   loop,

--- a/src/merge-child-reducers.js
+++ b/src/merge-child-reducers.js
@@ -1,0 +1,51 @@
+import {loop, isLoop, getModel, getCmd, Cmd} from '../src';
+
+export default function mergeChildReducers(parentResult, action, childMap){
+  let initialState = parentResult, parentCmd;
+  if(isLoop(initialState)){
+    parentCmd = getCmd(initialState);
+    initialState = getModel(initialState);
+  }
+
+  let cmds = parentCmd ? [parentCmd] : [];
+  let hasChanged = false;
+
+  const newState = Object.keys(childMap).reduce((prev, key) =>{
+    let childReducer = childMap[key];
+    if(!childReducer){
+      if(!hasChanged){
+        prev = {...prev};
+        hasChanged = true;
+      }
+      delete prev[key];
+      return prev;
+    }
+    let currentChild = childReducer(prev[key], action);
+    if(isLoop(currentChild)){
+      cmds.push(getCmd(currentChild));
+      currentChild = getModel(currentChild);
+    }
+
+    if(prev[key] !== currentChild && hasChanged){
+      prev[key] = currentChild;
+    }
+    else if(prev[key] !== currentChild){
+      prev = {...prev, [key]: currentChild};
+      hasChanged = true;
+    }
+    return prev;
+  }, initialState);
+
+  return loop(newState, getListCmdIfNeeded(cmds)); 
+}
+
+function getListCmdIfNeeded(cmds) {
+  switch(cmds.length) {
+    case 0:
+      return Cmd.none;
+    case 1:
+      return cmds[0];
+    default:
+      return Cmd.list(cmds);
+  }
+}

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -41,6 +41,7 @@ describe('combineReducers', () => {
   });
 
   it('works with custom data structure and returns correctly working reducer', () => {
+    let warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const appReducer = combineReducers(
       reducers,
       Map(),
@@ -74,5 +75,7 @@ describe('combineReducers', () => {
     action.previous = 2;
     state = getModel(appReducer(state, action));
     expect(state.toJS()).toEqual({ counter: 6, doubler: 32, fibonacci: 5 });
+
+    warn.mockRestore();
   });
 });

--- a/test/merge-child-reducers.spec.js
+++ b/test/merge-child-reducers.spec.js
@@ -1,0 +1,95 @@
+import {loop, Cmd, mergeChildReducers} from '../src';
+
+let adder = (state = 0, {value}) => state + value;
+let multiplier = (state = 1, {value}) => state * value;
+let adderCmd = (state = 0, {value}) => loop(state + value, Cmd.action({type: 'add'}));
+let multiplierCmd = (state = 1, {value}) => loop(state * value, Cmd.action({type: 'multiply'}));
+
+function foo(){}
+
+describe('mergeChildReducers', function(){
+  it('runs each child reducer and merges it onto the parent result, and returns a loop with Cmd.none', function(){
+    let state = {
+      foo: 'bar',
+      adder: 2,
+      multiplier: 3
+    };
+    const result = mergeChildReducers(state, {type: 'foo', value: 5}, {adder, multiplier});
+    let newState = {
+      foo: 'bar',
+      adder: 7,
+      multiplier: 15
+    };
+
+    expect(result).toEqual(loop(newState, Cmd.none));
+  });
+
+  it('creates the child properties if they do not exist already (and runs them with undefined state)', function(){
+    let state = {
+      foo: 'bar'
+    };
+    const result = mergeChildReducers(state, {type: 'foo', value: 3}, {adder, multiplier});
+    let newState = {
+      foo: 'bar',
+      adder: 3,
+      multiplier: 3
+    };
+    expect(result).toEqual(loop(newState, Cmd.none));
+  });
+
+  it('runs cmd from the parent result if it is a loop', function(){
+    const result = mergeChildReducers(loop({}, Cmd.run(foo)), {type: 'foo', value: 2}, {adder, multiplier});
+    let newState = {
+      adder: 2,
+      multiplier: 2
+    };
+    expect(result).toEqual(loop(newState, Cmd.run(foo)));
+  });
+
+  it('combines parent and children cmds together in a list', function(){
+    let map = {adderCmd, multiplierCmd};
+    let state = {
+      foo: 'bar',
+      adderCmd: 3,
+      multiplierCmd: 5
+    };
+    const result = mergeChildReducers(loop(state, Cmd.run(foo)), {type: 'foo', value: 10}, map);
+    let newState = {
+      foo: 'bar',
+      adderCmd: 13,
+      multiplierCmd: 50
+    };
+    let expectedCmds = [Cmd.run(foo), Cmd.action({type: 'add'}), Cmd.action({type: 'multiply'})];
+    expect(result).toEqual(loop(newState, Cmd.list(expectedCmds)));
+  });
+
+  it('will not add a child cmd to a list if it is the only one', function(){
+    let map = {adder, multiplierCmd};
+    let state = {
+      foo: 'bar',
+      adder: 3,
+      multiplierCmd: 5
+    };
+    const result = mergeChildReducers(state, {type: 'foo', value: 10}, map);
+    let newState = {
+      foo: 'bar',
+      adder: 13,
+      multiplierCmd: 50
+    };
+    expect(result).toEqual(loop(newState, Cmd.action({type: 'multiply'})));
+  });
+
+  it('removes slices of state that have null for their reducers in the map', function(){
+    let state = {
+      foo: 'bar',
+      adder: 2,
+      multiplier: 3
+    };
+    const result = mergeChildReducers(state, {type: 'foo', value: 5}, {adder: null, multiplier});
+    let newState = {
+      foo: 'bar',
+      multiplier: 15
+    };
+    expect(result).toEqual(loop(newState, Cmd.none));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,8 +7,8 @@ abab@^1.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
 abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 acorn-globals@^3.1.0:
   version "3.1.0"
@@ -34,20 +34,20 @@ acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+ajv-keywords@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
-ajv@^4.7.0, ajv@^4.9.1:
+ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -877,8 +877,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000718:
-  version "1.0.30000735"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000735.tgz#aab44016ef243e215ef43fd1343efd22930842f8"
+  version "1.0.30000743"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000743.tgz#f4f5c6750676ff8f6144ea40456c3729d5341769"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -891,7 +891,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1080,8 +1080,8 @@ debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
     ms "2.0.0"
 
 debug@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
@@ -1176,8 +1176,8 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
 
 electron-to-chromium@^1.3.18:
-  version "1.3.21"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz#9b7b88bb05ceb9fa016a177833cc2dde388f21b6"
 
 emoji-regex@^6.1.0:
   version "6.5.1"
@@ -1202,8 +1202,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.7.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -1464,9 +1464,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.9:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1524,8 +1524,8 @@ find-up@^2.0.0, find-up@^2.1.0:
     locate-path "^2.0.0"
 
 flat-cache@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
   dependencies:
     circular-json "^0.3.1"
     del "^2.0.2"
@@ -1821,8 +1821,8 @@ ignore@^3.3.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
 
 immutable@^3.7.6:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2502,7 +2502,7 @@ lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2704,14 +2704,14 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 "nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.1.tgz#7ae9b07b0ea804db7e25f05cb5fe4097d4e4949f"
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.2.tgz#c5e545ab40d22a56b0326531c4beaed7a888b3ea"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2934,11 +2934,12 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -3126,8 +3127,8 @@ request@2.81.0:
     uuid "^3.0.0"
 
 request@^2.79.0:
-  version "2.82.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.82.0.tgz#2ba8a92cd7ac45660ea2b10a53ae67cd247516ea"
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -3148,7 +3149,7 @@ request@^2.79.0:
     qs "~6.5.1"
     safe-buffer "^5.1.1"
     stringstream "~0.0.5"
-    tough-cookie "~2.3.2"
+    tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
@@ -3268,8 +3269,8 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 sane@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.0.0.tgz#99cb79f21f4a53a69d4d0cd957c2db04024b8eb2"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.2.0.tgz#d6d2e2fcab00e3d283c93b912b7c3a20846f1d56"
   dependencies:
     anymatch "^1.3.0"
     exec-sh "^0.2.0"
@@ -3277,7 +3278,7 @@ sane@^2.0.0:
     minimatch "^3.0.2"
     minimist "^1.1.1"
     walker "~1.0.5"
-    watch "~0.10.0"
+    watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.1.1"
 
@@ -3323,9 +3324,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3402,7 +3405,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -3474,15 +3477,15 @@ symbol-tree@^3.2.1:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 table@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -3541,7 +3544,7 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.2:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -3605,8 +3608,8 @@ uglify-js@^2.6:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.0.9:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.1.tgz#e7144307281a1bc38a9a20715090b546c9f44791"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.3.tgz#d61f0453b4718cab01581f3162aa90bab7520b42"
   dependencies:
     commander "~2.11.0"
     source-map "~0.5.1"
@@ -3653,8 +3656,8 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 vlq@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 walker@~1.0.5:
   version "1.0.7"
@@ -3662,9 +3665,12 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-watch@~0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+watch@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
I've been using an implementation mergeChildReducers in project I work on for a while and have found it very useful. I think it'd be good for us to expose it as part of the library to ease nesting of reducers for people.

Also, since I broke out immutablejs specific helpers into https://github.com/redux-loop/redux-loop-immutable, I think we should stop supporting a generic combineReducers. They are not as good as custom solutions so I'd rather not enable using them. [Redux does the same thing too](http://redux.js.org/docs/recipes/reducers/BeyondCombineReducers.html).