### PR TITLE
Improve testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ state and always get a result which is `deepEqual`.
 > not equal within JavaScript, and so are best to avoid if you want to compare
 > effects in your tests.
 
+#### Simulating Cmds
+
+Occasionally you may find yourself in a situation where you need to pass more than one parameter to an action creator, such as:
+
+```js
+Cmd.run(foo, {
+  successActionCreator: foo => actionCreator(foo, state.blah)
+})
+```
+
+You can't do a deep equality check on this because the success action creator is always new. Instead, you can simulate the cmd to test the action creators.
+
+```js
+import { Cmd, getCmd, getModel } from 'redux-loop';
+...
+
+let result = reducer(state, action);
+expect(getModel(result)).toEqual(whatever);
+let cmd = getCmd(result);
+
+//test the rest of the cmd
+expect(cmd).toEqual(Cmd.run(foo, {
+  successActionCreator: jasmine.any(Function) //replace with your testing library's equivalent matcher
+}));
+
+expect(cmd.simulate({success: true, result: 123})).toEqual(actionCreator(123, state.blah));
+expect(cmd.simulate({success: false, result: 123})).toBe(null);
+
+```
+
+You can simulate any Cmd to test the actions returned. Lists take arrays of simulations for their child cmds.
+
+[See detailed documentation about simulating Cmds](docs/ApiDocs.md)
+
 ### Avoid circular loops!
 
 ```js

--- a/docs/ApiDocs.md
+++ b/docs/ApiDocs.md
@@ -330,6 +330,7 @@ function reducer(state , action) {
   other cmd functions, or even nested calls to `Cmd.list`.
 * `options.sequence: boolean` &ndash; By default, asynchronous Cmds all run immediately and in parallel. If sequence is true, cmds will wait for the previous cmd to resolve before starting. Note: this does not have an effect if all Cmds are synchronous.
 * `options.batch: boolean` &ndash; By default, actions from nested cmds will be dispatched as soon as that cmd finishes. If batch is true, no actions will be dispatched until all of the cmds are resolved/finished. The actions will then be dispatched all at once in the order of the original cmd array.
+* `options.testInvariants: boolean` &ndash; Normally, if the first parameter to Cmd.list is not an array of Cmds, an error will be thrown (unless you are in production). You can turn this off in testing environments by using this option. NOTE: ONLY DO THIS IN TESTS. IF YOU DO THIS IN PRODUCTION, IT WILL THROW. This is useful if you want to pass a custom object from your test library to verify a subset of `cmds`, such as `jasmine.arrayContaining(someCmd)`.
 
 #### Notes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,20 @@ export interface LiftedLoopReducer<S, A extends Action> {
   (state: S | undefined, action: AnyAction): Loop<S, A>;
 }
 
+export type CmdSimulation = {
+  result: any,
+  success: boolean
+};
+export interface MultiCmdSimulation {
+  [index: number]: CmdSimulation | MultiCmdSimulation;
+}
+
+type SingleCmdSimulationFunction<A extends Action> = (simulation?: CmdSimulation) => A;
+type MultiCmdSimulationFunction<A extends Action> = (simulations: MultiCmdSimulation) => A[];
+
 export interface NoneCmd {
   type: 'NONE';
+  simulate: SingleCmdSimulationFunction<AnyAction>;
 }
 
 export interface ListCmd<A extends Action> {
@@ -27,11 +39,13 @@ export interface ListCmd<A extends Action> {
   cmds: CmdType<A>[];
   sequence?: boolean;
   batch?: boolean;
+  simulate: MultiCmdSimulationFunction<A>;
 }
 
 export interface ActionCmd<A extends Action> {
   type: 'ACTION';
   actionToDispatch: A;
+  simulate: SingleCmdSimulationFunction<A>;
 }
 
 export interface MapCmd<A extends Action> {
@@ -39,6 +53,7 @@ export interface MapCmd<A extends Action> {
   tagger: ActionCreator<A>;
   nestedCmd: CmdType<A>;
   args: any[];
+  simulate: SingleCmdSimulationFunction<A> | MultiCmdSimulationFunction<A>;
 }
 
 export interface RunCmd<A extends Action> {
@@ -48,6 +63,7 @@ export interface RunCmd<A extends Action> {
   failActionCreator?: ActionCreator<A>;
   successActionCreator?: ActionCreator<A>;
   forceSync?: boolean;
+  simulate: SingleCmdSimulationFunction<A>;
 }
 
 //deprecated types
@@ -68,7 +84,7 @@ declare function install<S>(): StoreEnhancer<S>;
 
 declare function loop<S, A extends Action>(
   state: S,
-  loop: CmdType<A>
+  cmd: CmdType<A>
 ): Loop<S, A>;
 
 declare class Cmd {

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -184,7 +184,7 @@ const action = (actionToDispatch) => {
 const list = (cmds, options = {}) => {
   if (process.env.NODE_ENV !== 'production') {
     throwInvariant(
-      Array.isArray(cmds) && cmds.every(isCmd),
+      (Array.isArray(cmds) || options.testInvariants) && cmds.every(isCmd),
       'Cmd.list: first argument to Cmd.list must be an array of other Cmds'
     )
 
@@ -193,12 +193,17 @@ const list = (cmds, options = {}) => {
       'Cmd.list: second argument to Cmd.list must be an options object'
     )
   }
+  else if(options.testInvariants){
+    throw Error('Redux Loop: Detected usage of Cmd.list\'s testInvariants option in production code. This should only be used in tests.');
+  }
+
+  const {testInvariants, ...rest} = options;
 
   return Object.freeze({
     [isCmdSymbol]: true,
     type: cmdTypes.LIST,
     cmds,
-    ...options
+    ...rest
   });
 }
 

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -7,6 +7,7 @@ import {
   liftState,
   LoopReducer
 } from '../../index';
+import { AnyAction } from 'redux';
 
 type TodoState = { todos: string[]; nestedCounter: number };
 
@@ -105,3 +106,18 @@ const rootState: RootState = rootReducer(undefined, {
   type: 'ADD_TODO',
   text: 'test'
 })[0];
+
+let cmd = Cmd.run(() => {}, {
+  successActionCreator: a => ({type: 'FOO', a: 2*a})
+});
+let action: AnyAction = cmd.simulate({success: true, result: 123});
+let listCmd = Cmd.list([cmd, cmd]);
+let actions: AnyAction[] = listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
+let nestedListCmd = Cmd.list([cmd, listCmd]);
+let flattenedActions: AnyAction[] = nestedListCmd.simulate([
+  {success: true, result: 123},
+  [
+    {success: true, result: 456},
+    {success: true, result: 789},
+  ]
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,8 +877,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000718:
-  version "1.0.30000743"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000743.tgz#f4f5c6750676ff8f6144ea40456c3729d5341769"
+  version "1.0.30000744"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000744.tgz#860fa5c83ba34fe619397d607f30bb474821671b"
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Addresses some of the issues in #137. Enables simulation of cmds and disabling invariants for testing matchers.

 @gniquil and @jon-thompson I haven't done the tests or doc changes yet. I want to see what you think of this implementation first.

Basically, now you can say

```js
//Cmd.run
expect(getCmd(result).simulate({result: 123, success: true})).toEqual(actionCreator(123));
expect(getCmd(result).simulate({result: 123, success: false})).toBe(null);

//Cmd.actiom
expect(getCmd(result).simulate()).toEqual(actionIPassedToCmd);

//Cmd.list
expect(getCmd(result).simulate([
  {result: 123, success: true},
  {result: 456, success: false}
])).toEqual([actionCreator1(123), actionCreator2(456]);
```

alternatively, we can expose something like Cmd.simulate(cmd, simulation), but I kind of like it on the cmd itself. Another option is to break this logic out into a separate package, but I think it's simple enough to not bother.