### PR TITLE
fix RunCmd and ListCmd types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,10 +25,8 @@ export interface NoneCmd {
 export interface ListCmd<A extends Action> {
   type: 'LIST';
   cmds: CmdType<A>[];
-  options: {
-    sequence: boolean;
-    batch: boolean;
-  };
+  sequence?: boolean;
+  batch?: boolean;
 }
 
 export interface ActionCmd<A extends Action> {
@@ -46,12 +44,10 @@ export interface MapCmd<A extends Action> {
 export interface RunCmd<A extends Action> {
   type: 'RUN';
   func: Function;
-  options: {
-    args: any[];
-    failActionCreator: ActionCreator<A>;
-    successActionCreator: ActionCreator<A>;
-    forceSync: boolean;
-  };
+  args?: any[];
+  failActionCreator?: ActionCreator<A>;
+  successActionCreator?: ActionCreator<A>;
+  forceSync?: boolean;
 }
 
 //deprecated types


### PR DESCRIPTION
quick fix to the types of interfaces returned by ListCmd and RunCmd -- shouldn't affect many end users because it's mainly just handled internally by `redux-loop`, but `options` gets spread so `args` wouldn't exist inside of an options object here for example:

```
  return Object.freeze({
    [isCmdSymbol]: true,
    type: cmdTypes.RUN,
    func,
    ...options
  })
```