### PR TITLE
Upgrade peerDependency for redux to ^3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "Luke William Westby <luke.westby@raise.com>",
   "license": "MIT",
   "peerDependencies": {
-    "redux": "^3.0.0"
+    "redux": "^3.7.2"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION
redux-loop/index.d.ts relies on the `AnyAction` type introduced in `redux@3.7.2` (https://github.com/reactjs/redux/pull/2467#issuecomment-314933101).

AFAIK, the redux-loop implementation itself doesn't depend on features introduced in `3.7.2`.

If we want to keep the peerDependency at `redux@^3.0.0`, an alternate solution would be removing the `AnyAction` import and defining it ourselves. This doesn't seem like that big a deal: https://github.com/reactjs/redux/blob/master/index.d.ts#L25