### PR TITLE
Add clear cmdsQueue after replace reducer

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -51,7 +51,8 @@ export function install() {
     }
 
     const replaceReducer = (reducer) => {
-      return store.replaceReducer(liftReducer(reducer))
+      store.replaceReducer(liftReducer(reducer))
+      cmdsQueue = []
     }
 
     runCmd({


### PR DESCRIPTION
After dynamically replace reducer and dispatch any action, old cmds running again.

Example: http://s.csssr.ru/U5E1S7FNC/20180301163042.png
In example, after "LOCATION_CHANGE", i will replace reducer and call dispatch.
Old cmd ''[3] items/ACTION", running again.