### PR TITLE
Pass whole state as 3rd param for reducer in combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -42,7 +42,7 @@ export const combineReducers = (
     const model = Object.keys(reducerMap).reduce((model, key) => {
       const reducer = reducerMap[key]
       const previousStateForKey = accessor(state, key)
-      let nextStateForKey = reducer(previousStateForKey, action)
+      let nextStateForKey = reducer(previousStateForKey, action, state)
 
       if (isLoop(nextStateForKey)) {
         cmds.push(getCmd(nextStateForKey))


### PR DESCRIPTION
This lets sub-reducers access the whole state. It is useful in some
situation where you want to separate conceptual models but you still
need some bit of info from a sibling reducer.

For example, I like to have a separate auth reducer where I handle user specific actions and where I store the logged in user etc.
But any given reducer might need information about logged in user for some of its updates and it can be much more code to thread the user from the ui and pass it into actions etc.
In fact, this is the exact use-case that I have right now and where I feel this third parameter would be useful.

It would let me write:

```javascript
export const reducer = (state = initialState, action, wholeState) => {
  switch (action.type) {
    case types.SEND_MESSAGE:
      const id = uuid.v4()
      return loop(
        {
          ...state,
          text: '',
          messages: [
            ...state.messages,
            {
              message_id: id,
              showAvatar: true,
              from_id: wholeState.auth.user.id,
              message: state.text,
              sending: true,
            }
          ]
        },
        Cmd.none // Actual Cmd is not interesting here
      )
    default:
      return state
  }
}
```

Unless I'm mistaken, If I didn't have the whole state here as 3rd parameter I would need to make up a second action to which I would pass Cmd.getState as a parameter, have that eventually dispatch this with the user id as argument and that sounds way too convoluted to be useful and clean enough.