### PR TITLE
Made Cmd types more precise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ export type CmdType<A extends Action> =
   | RunCmd<A>
   | BatchCmd<A>
   | SequenceCmd<A>;
-  
+
 declare function install<S>(): StoreEnhancer<S>;
 
 declare function loop<S, A extends Action>(
@@ -87,29 +87,29 @@ declare function loop<S, A extends Action>(
   cmd: CmdType<A>
 ): Loop<S, A>;
 
-declare class Cmd {
-  static readonly dispatch: (action: Action) => void;
-  static readonly getState: any;
-  static readonly none: NoneCmd;
-  static readonly action: <A extends Action>(action: A) => ActionCmd<A>;
-  static readonly batch: <A extends Action>(cmds: CmdType<A>[]) => BatchCmd<A>;
-  static readonly sequence: <A extends Action>(cmds: CmdType<A>[]) => SequenceCmd<A>;
+declare namespace Cmd {
+  export const dispatch: unique symbol;
+  export const getState: unique symbol;
+  export const none: NoneCmd;
+  export const action: <A extends Action>(action: A) => ActionCmd<A>;
+  export const batch: <A extends Action>(cmds: CmdType<A>[]) => BatchCmd<A>;
+  export const sequence: <A extends Action>(cmds: CmdType<A>[]) => SequenceCmd<A>;
 
-  static readonly list: <A extends Action>(
+  export function list<A extends Action>(
     cmds: CmdType<A>[],
     options?: {
       batch?: boolean;
       sequence?: boolean;
     }
-  ) => ListCmd<A>;
+  ): ListCmd<A>;
 
-  static readonly map: <A extends Action, B extends Action>(
+  export function map<A extends Action, B extends Action>(
     cmd: CmdType<B>,
     tagger: (subAction: B) => A,
     args?: any[]
-  ) => MapCmd<A>;
+  ): MapCmd<A>;
 
-  static readonly run: <A extends Action>(
+  export function run<A extends Action>(
     f: Function,
     options?: {
       args?: any[];
@@ -117,7 +117,7 @@ declare class Cmd {
       successActionCreator?: ActionCreator<A>;
       forceSync?: boolean;
     }
-  ) => RunCmd<A>;
+  ): RunCmd<A>;
 }
 
 export type ReducerMapObject<S, A extends Action = AnyAction> = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,44 +26,41 @@ export interface MultiCmdSimulation {
   [index: number]: CmdSimulation | MultiCmdSimulation;
 }
 
-type SingleCmdSimulationFunction<A extends Action> = (simulation?: CmdSimulation) => A;
-type MultiCmdSimulationFunction<A extends Action> = (simulations: MultiCmdSimulation) => A[];
-
 export interface NoneCmd {
-  type: 'NONE';
-  simulate: SingleCmdSimulationFunction<AnyAction>;
+  readonly type: 'NONE';
+  simulate(): null;
 }
 
 export interface ListCmd<A extends Action> {
-  type: 'LIST';
-  cmds: CmdType<A>[];
-  sequence?: boolean;
-  batch?: boolean;
-  simulate: MultiCmdSimulationFunction<A>;
+  readonly type: 'LIST';
+  readonly cmds: CmdType<A>[];
+  readonly sequence?: boolean;
+  readonly batch?: boolean;
+  simulate(simulations: MultiCmdSimulation): A[];
 }
 
 export interface ActionCmd<A extends Action> {
-  type: 'ACTION';
-  actionToDispatch: A;
-  simulate: SingleCmdSimulationFunction<A>;
+  readonly type: 'ACTION';
+  readonly actionToDispatch: A;
+  simulate(): A;
 }
 
 export interface MapCmd<A extends Action> {
-  type: 'MAP';
-  tagger: ActionCreator<A>;
-  nestedCmd: CmdType<A>;
-  args: any[];
-  simulate: SingleCmdSimulationFunction<A> | MultiCmdSimulationFunction<A>;
+  readonly type: 'MAP';
+  readonly tagger: ActionCreator<A>;
+  readonly nestedCmd: CmdType<A>;
+  readonly args: any[];
+  simulate(simulations?: CmdSimulation | MultiCmdSimulation): A[] | A | null
 }
 
 export interface RunCmd<A extends Action> {
-  type: 'RUN';
-  func: Function;
-  args?: any[];
-  failActionCreator?: ActionCreator<A>;
-  successActionCreator?: ActionCreator<A>;
-  forceSync?: boolean;
-  simulate: SingleCmdSimulationFunction<A>;
+  readonly type: 'RUN';
+  readonly func: Function;
+  readonly args?: any[];
+  readonly failActionCreator?: ActionCreator<A>;
+  readonly successActionCreator?: ActionCreator<A>;
+  readonly forceSync?: boolean;
+  simulate(simulation: CmdSimulation): A
 }
 
 //deprecated types
@@ -88,18 +85,19 @@ declare function loop<S, A extends Action>(
 ): Loop<S, A>;
 
 declare namespace Cmd {
-  export const dispatch: unique symbol;
-  export const getState: unique symbol;
+  export const dispatch: symbol;
+  export const getState: symbol;
   export const none: NoneCmd;
-  export const action: <A extends Action>(action: A) => ActionCmd<A>;
-  export const batch: <A extends Action>(cmds: CmdType<A>[]) => BatchCmd<A>;
-  export const sequence: <A extends Action>(cmds: CmdType<A>[]) => SequenceCmd<A>;
+  export function action<A extends Action>(action: A): ActionCmd<A>;
+  export function batch<A extends Action>(cmds: CmdType<A>[]): BatchCmd<A>;
+  export function sequence<A extends Action>(cmds: CmdType<A>[]): SequenceCmd<A>;
 
   export function list<A extends Action>(
     cmds: CmdType<A>[],
     options?: {
       batch?: boolean;
       sequence?: boolean;
+      testInvariants?: boolean;
     }
   ): ListCmd<A>;
 

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -119,7 +119,7 @@ export const executeCmd = (cmd, dispatch, getState) => {
     case cmdTypes.MAP:
       const possiblePromise = executeCmd(cmd.nestedCmd, dispatch, getState)
       if (!possiblePromise) return null
-      return possiblePromise.then((actions) => 
+      return possiblePromise.then((actions) =>
         actions.map(action => cmd.tagger(...cmd.args, action))
       );
 

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -29,7 +29,7 @@ const updateNestedCounter = (subAction: CounterActions): TodoActions => ({
 });
 
 const todosReducer: LoopReducer<TodoState, TodoActions> = (
-  state: TodoState,
+  state: TodoState = { todos: [], nestedCounter: 0 },
   action: TodoActions
 ): TodoState | Loop<TodoState, TodoActions> => {
   switch (action.type) {
@@ -79,7 +79,7 @@ type CounterActions = {
 };
 
 const counterReducer: LoopReducer<CounterState, CounterActions> = (
-  state: CounterState,
+  state: CounterState = 0,
   action: CounterActions
 ): CounterState => {
   switch (action.type) {


### PR DESCRIPTION
- Marked `CmdType` properties as readonly, since a frozen object is returned
- Used unique `simulate()` functions on each `CmdType` interface.
- `Cmd` is now a namespace instead of a static class, to reflect that its exported as an object.
- Fixed typescript tests