### PR TITLE
Removed console.error on command promise failure if failActionCreator exists

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -33,7 +33,9 @@ function handleRunCmd(cmd, dispatch, getState){
 
     if (isPromiseLike(result) && !cmd.forceSync){
       return result.then( onSuccess, (error) => {
-        console.error(error);
+        if(!cmd.failActionCreator){
+          console.error(error);
+        }
         return onFail(error);
       })
       .then(action => action ? [action] : [])


### PR DESCRIPTION
`4.4.1` introduced a bug where `console.error` is always called on command promise failures, even if a `failActionCreator` exists.

This isn't particularly impeding on web projects, but is a showstopper in React Native projects since `console.error` throws up a red fullscreen error message UI.