### PR TITLE
add config to control logging of effect errors even when handled

### DIFF
--- a/docs/api-docs/install.md
+++ b/docs/api-docs/install.md
@@ -1,4 +1,11 @@
-# `install`
+# `install(config)`
+
+* `config: Object<string, Boolean>` &ndash; an optional map of config values to override default
+ redux-loop configs
+*  Currently the only option is `DONT_LOG_ERRORS_ON_HANDLED_FAILURES` which is set 
+   to false by default. This means that by default, redux-loop will log errors in your 
+   effects even if you pass in a failActionCreator to a command (passing in a 
+   failActionCreator does not swallow errors like how `catch` is used for Promises). 
 
 ## Notes
 
@@ -41,4 +48,17 @@ const enhancer = compose(
 );
 
 const store = createStore(reducer, initialState, enhancer);
+```
+
+### With config option to not log errors on handled failures
+```js
+import { createStore } from 'redux';
+import { install } from 'redux-loop';
+import reducer from './reducer';
+const initialState = { /* ... */ };
+
+const config = { DONT_LOG_ERRORS_ON_HANDLED_FAILURES: true };
+const store = createStore(reducer, initialState, install(config));
+const reducer = combineReducers({reducer1, reducer2});
+reducer(undefined, {type: 'foo'}, 'abc');
 ```

--- a/src/install.js
+++ b/src/install.js
@@ -2,7 +2,13 @@ import { liftState } from './loop'
 import { executeCmd } from './cmd'
 import { loopPromiseCaughtError } from './errors'
 
-export function install() {
+const defaultLoopConfig = {
+  DONT_LOG_ERRORS_ON_HANDLED_FAILURES: false
+}
+
+export function install(config={}) {
+  const loopConfig = Object.assign({}, defaultLoopConfig, config)
+
   return (next) => (reducer, initialState, enhancer) => {
     const [initialModel, initialCmd] = liftState(initialState)
     let cmdsQueue = []
@@ -28,7 +34,7 @@ export function install() {
     }
 
     const runCmd = ({ originalAction, cmd }) => {
-      const cmdPromise = executeCmd(cmd, dispatch, store.getState)
+      const cmdPromise = executeCmd(cmd, dispatch, store.getState, loopConfig)
 
       if (!cmdPromise) return null
 


### PR DESCRIPTION
Add a config option to install.

 Currently the only option is `DONT_LOG_ERRORS_ON_HANDLED_FAILURES` (see https://github.com/redux-loop/redux-loop/pull/194, which fixed the issue where error messages were being swallowed in effects when the client added a failActionHandler on a Cmd) which is set to false by default. This means that by default, redux-loop will log errors in your effects even if you pass in a failActionCreator to a command (passing in a failActionCreator does not swallow errors like how `catch` is used for Promises). 