### PR TITLE
Fix: Show addition result of addReducer in docs

### DIFF
--- a/docs/tutorial/AdvancedTopics.md
+++ b/docs/tutorial/AdvancedTopics.md
@@ -73,7 +73,7 @@ const initialState = { add: 5, mult: 7 };
 const store = createStore(reducer, initialState, install());
 
 dispatch({type: 'change', value: 6});
-// state is { add: 30, mult: 42 }
+// state is { add: 11, mult: 42 }
 // foo and bar have run
 ```
 


### PR DESCRIPTION
The result of addReducer should be to add the change value (6 in this case) to the state's add property (5 in this case) so it would be 11 and not 30 like you would get from multiplying.