### PR TITLE
Have dispatch return the action it's provided after the current loop concludes

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -50,10 +50,10 @@ export function install(config={}) {
     }
 
     const dispatch = (action) => {
-      store.dispatch(action)
+      const result = store.dispatch(action)
       const cmdsToRun = cmdsQueue
       cmdsQueue = []
-      return runCmds(cmdsToRun)
+      return runCmds(cmdsToRun).then(() => result);
     }
 
     const replaceReducer = (reducer) => {


### PR DESCRIPTION
The vanilla implementation of redux [passes the provided action back](https://github.com/reduxjs/redux/blob/628ffdd4c5a1b2e4e5b42b26ec8f7b29c344bf0c/src/createStore.js#L208) as a convenience. [The doc comment](https://github.com/reduxjs/redux/blob/628ffdd4c5a1b2e4e5b42b26ec8f7b29c344bf0c/src/createStore.js#L173-L174) does mention that this isn't guaranteed behavior across middleware/store enhancers, but during our transition to `redux-loop` from `redux-thunk`, this characteristic of `dispatch` is important because it was pretty heavily relied on in the past.

Just looking at the code, it's unclear why we do *not* return the provided action. Especially if there are multiple actions in the [cmdRun queue](https://github.com/redux-loop/redux-loop/blob/d811096459104856b4bb7eaf8e8f641b1c23c3fd/src/install.js#L32), we seem to discard the result of the Promises. 

Applying this change has not broken our limited usage of `redux-loop`, and I'm curious if it may break in other places.

Thanks!

