### PR TITLE
Relax reduceReducers typing to match implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export interface LoopReducer<S, A extends Action> {
   (state: S | undefined, action: AnyAction, ...args: any[]): S | Loop<S, A>;
 }
 
-export interface NonInitialLoopReducer<S, A extends Action> {
+export interface LoopReducerWithDefinedState<S, A extends Action> {
   (state: S, action: AnyAction, ...args: any[]): S | Loop<S, A>;
 }
 
@@ -142,7 +142,7 @@ declare function mergeChildReducers<S, A extends Action = AnyAction>(
 
 declare function reduceReducers<S, A extends Action = AnyAction>(
   initialReducer: LoopReducer<S, A>,
-  ...reducers: Array<NonInitialLoopReducer<S, A>>
+  ...reducers: Array<LoopReducerWithDefinedState<S, A>>
 ): LiftedLoopReducer<S, A>;
 
 declare function liftState<S, A extends Action>(

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,10 @@ export interface LoopReducer<S, A extends Action> {
   (state: S | undefined, action: AnyAction, ...args: any[]): S | Loop<S, A>;
 }
 
+export interface NonInitialLoopReducer<S, A extends Action> {
+  (state: S, action: AnyAction, ...args: any[]): S | Loop<S, A>;
+}
+
 export interface LiftedLoopReducer<S, A extends Action> {
   (state: S | undefined, action: AnyAction, ...args: any[]): Loop<S, A>;
 }
@@ -137,7 +141,8 @@ declare function mergeChildReducers<S, A extends Action = AnyAction>(
 ): Loop<S, A>;
 
 declare function reduceReducers<S, A extends Action = AnyAction>(
-  ...reducers: Array<LoopReducer<S, A>>
+  initialReducer: LoopReducer<S, A>,
+  ...reducers: Array<NonInitialLoopReducer<S, A>>
 ): LiftedLoopReducer<S, A>;
 
 declare function liftState<S, A extends Action>(

--- a/test/typescript/reduce-reducers.ts
+++ b/test/typescript/reduce-reducers.ts
@@ -2,7 +2,7 @@ import {
   reduceReducers,
   Loop,
   LoopReducer,
-  NonInitialLoopReducer,
+  LoopReducerWithDefinedState,
   getModel,
   getCmd,
   CmdType
@@ -32,7 +32,7 @@ const addReducer: LoopReducer<ReducedState, ReducedActions> = (
   return state;
 };
 
-const multReducer: NonInitialLoopReducer<ReducedState, ReducedActions> = (
+const multReducer: LoopReducerWithDefinedState<ReducedState, ReducedActions> = (
   state,
   action: AnyAction
 ) => {

--- a/test/typescript/reduce-reducers.ts
+++ b/test/typescript/reduce-reducers.ts
@@ -2,6 +2,7 @@ import {
   reduceReducers,
   Loop,
   LoopReducer,
+  NonInitialLoopReducer,
   getModel,
   getCmd,
   CmdType
@@ -31,8 +32,8 @@ const addReducer: LoopReducer<ReducedState, ReducedActions> = (
   return state;
 };
 
-const multReducer: LoopReducer<ReducedState, ReducedActions> = (
-  state = initialState,
+const multReducer: NonInitialLoopReducer<ReducedState, ReducedActions> = (
+  state,
   action: AnyAction
 ) => {
   if(action.type === 'change'){


### PR DESCRIPTION
Previously the typescript types for the `reduceReducers` function required all of the reducers to handle the initial `undefined` state, although the actual implementation ensures that only the first reducer to only ever receive an `undefined` state. The types thus forced all the reducers to implement some unnecessary handling for the initial state.

This PR allows all but the first reducer to assume that the state they receive is always initialised.