### PR TITLE
Update TypeScript types for Cmd.run()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,12 +115,12 @@ declare namespace Cmd {
     args?: any[]
   ): MapCmd<A>;
 
-  export function run<A extends Action>(
+  export function run<A extends Action, B extends Action>(
     f: Function,
     options?: {
       args?: any[];
       failActionCreator?: ActionCreator<A>;
-      successActionCreator?: ActionCreator<A>;
+      successActionCreator?: ActionCreator<B>;
       forceSync?: boolean;
     }
   ): RunCmd<A>;

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -9,6 +9,10 @@ import {
 } from '../../index';
 import { AnyAction } from 'redux';
 
+const FETCH_FOO_REQUEST = 'FETCH_FOO_REQUEST'
+const FETCH_FOO_SUCCESS = 'FETCH_FOO_SUCCESS'
+const FETCH_FOO_FAILURE = 'FETCH_FOO_FAILURE'
+
 type TodoState = { todos: string[]; nestedCounter: number };
 
 type TodoActions =
@@ -17,7 +21,10 @@ type TodoActions =
       text: string;
     }
   | { type: 'NOOP' }
-  | { type: 'UPDATE_NESTED_COUNTER'; subAction: CounterActions };
+  | { type: 'UPDATE_NESTED_COUNTER'; subAction: CounterActions }
+  | IFetchFooRequest
+  | IFetchFooSuccess
+  | IFetchFooFailure
 
 const noop = (): TodoActions => ({
   type: 'NOOP'
@@ -27,6 +34,28 @@ const updateNestedCounter = (subAction: CounterActions): TodoActions => ({
   type: 'UPDATE_NESTED_COUNTER',
   subAction
 });
+
+interface IFetchFooRequest {
+  type: typeof FETCH_FOO_REQUEST
+}
+
+interface IFetchFooSuccess {
+  type: typeof FETCH_FOO_SUCCESS
+}
+
+const fetchFooSuccess = (): IFetchFooSuccess => ({
+  type: FETCH_FOO_SUCCESS,
+})
+
+interface IFetchFooFailure {
+  type: typeof FETCH_FOO_FAILURE
+}
+
+const fetchFooFailure = (): IFetchFooFailure => ({
+  type: FETCH_FOO_FAILURE,
+})
+
+const apiFetchFoo = () => Promise.resolve("foo")
 
 const todosReducer: LoopReducer<TodoState, TodoActions> = (
   state: TodoState = { todos: [], nestedCounter: 0 },
@@ -48,6 +77,14 @@ const todosReducer: LoopReducer<TodoState, TodoActions> = (
         { ...state, nestedCounter: model },
         Cmd.map(cmd, updateNestedCounter)
       );
+    case FETCH_FOO_REQUEST:
+      return loop(
+        state,
+        Cmd.run(apiFetchFoo, {
+          successActionCreator: fetchFooSuccess,
+          failActionCreator: fetchFooFailure,
+        })
+      )
     default:
       return loop(
         state,


### PR DESCRIPTION
## Before

When using defining action creators that return their specific action instead of the union of all actions, there would be a type error with `Cmd.run`

## After

Action creators that return different actions in the union of actions can be using by `Cmd.run()`

## Example

Here is an example that breaks with the current typings:

```typescript
interface IFetchFooRequest {
  type: typeof FETCH_FOO_REQUEST
}

interface IFetchFooSuccess {
  type: typeof FETCH_FOO_SUCCESS
}

const fetchFooSuccess = (): IFetchFooSuccess => ({
  type: FETCH_FOO_SUCCESS,
})

interface IFetchFooFailure {
  type: typeof FETCH_FOO_FAILURE
}

const fetchFooFailure = (): IFetchFooFailure => ({
  type: FETCH_FOO_FAILURE,
})

// --snip--
    case FETCH_FOO_REQUEST:
      return loop(
        state,
        Cmd.run(apiFetchFoo, {
          successActionCreator: fetchFooSuccess,
          failActionCreator: fetchFooFailure,
    // [ts]
    // Argument of type '{ successActionCreator: () => IFetchFooSuccess; failActionCreator: () => IFetchFooFailure; }' is not assignable to parameter of type '{ args?: any[] | undefined; failActionCreator?: ActionCreator<IFetchFooFailure> | undefined; successActionCreator?: ActionCreator<IFetchFooFailure> | undefined; forceSync?: boolean | undefined; }'.
    //   Types of property 'successActionCreator' are incompatible.
    //     Type '() => IFetchFooSuccess' is not assignable to type 'ActionCreator<IFetchFooFailure>'.
    //       Type 'IFetchFooSuccess' is not assignable to type 'IFetchFooFailure'.
    //         Types of property 'type' are incompatible.
    //           Type '"FETCH_FOO_SUCCESS"' is not assignable to type '"FETCH_FOO_FAILURE"'. [2345]

// --snip--
```

This isn't an issue when typing action creators to return the union `Action`. However, if you use something like [`typesafe-actions`](https://github.com/piotrwitek/typesafe-actions) which constructs the union of actions using the `ReturnType` of action creators there are type errors.