### PR TITLE
Fix StoreCreator TypeScript def to match redux

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Action, ActionCreator, AnyAction, StoreEnhancer, Store } from 'redux';
 export interface StoreCreator {
   <S, A extends Action>(
     reducer: LoopReducer<S, A>,
-    preloadedState: S,
+    preloadedState: S | undefined,
     enhancer: StoreEnhancer<S>
   ): Store<S>;
 }
@@ -84,7 +84,7 @@ export type CmdType<A extends Action> =
 export interface LoopConfig {
   readonly DONT_LOG_ERRORS_ON_HANDLED_FAILURES: boolean;
 }
-  
+
 declare function install<S>(config?: LoopConfig): StoreEnhancer<S>;
 
 declare function loop<S, A extends Action>(

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -9,7 +9,7 @@ import {
   LoopReducer,
   StoreCreator,
 } from '../../index';
-import { AnyAction, compose, createStore } from 'redux';
+import { AnyAction, createStore } from 'redux';
 
 const FETCH_FOO_REQUEST = 'FETCH_FOO_REQUEST'
 const FETCH_FOO_SUCCESS = 'FETCH_FOO_SUCCESS'
@@ -164,7 +164,7 @@ let flattenedActions: AnyAction[] = nestedListCmd.simulate([
 ]);
 
 const enhancedCreateStore = createStore as StoreCreator;
-const enhancer = compose(install<TodoState>());
+const enhancer = install<TodoState>();
 
 const storeWithPreloadedState = enhancedCreateStore(
   todosReducer, initialTodoState, enhancer

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -1,19 +1,23 @@
 import {
   Cmd,
   combineReducers,
+  install,
   loop,
   Loop,
   LiftedLoopReducer,
   liftState,
-  LoopReducer
+  LoopReducer,
+  StoreCreator,
 } from '../../index';
-import { AnyAction } from 'redux';
+import { AnyAction, compose, createStore } from 'redux';
 
 const FETCH_FOO_REQUEST = 'FETCH_FOO_REQUEST'
 const FETCH_FOO_SUCCESS = 'FETCH_FOO_SUCCESS'
 const FETCH_FOO_FAILURE = 'FETCH_FOO_FAILURE'
 
 type TodoState = { todos: string[]; nestedCounter: number };
+
+const initialTodoState: TodoState = { todos: [], nestedCounter: 0 };
 
 type TodoActions =
   | {
@@ -58,7 +62,7 @@ const fetchFooFailure = (): IFetchFooFailure => ({
 const apiFetchFoo = () => Promise.resolve("foo")
 
 const todosReducer: LoopReducer<TodoState, TodoActions> = (
-  state: TodoState = { todos: [], nestedCounter: 0 },
+  state: TodoState = initialTodoState,
   action: AnyAction
 ) => {
   switch (action.type) {
@@ -158,3 +162,14 @@ let flattenedActions: AnyAction[] = nestedListCmd.simulate([
     {success: true, result: 789},
   ]
 ]);
+
+const enhancedCreateStore = createStore as StoreCreator;
+const enhancer = compose(install<TodoState>());
+
+const storeWithPreloadedState = enhancedCreateStore(
+  todosReducer, initialTodoState, enhancer
+);
+
+const storeWithoutPreloadedState = enhancedCreateStore(
+  todosReducer, undefined, enhancer
+);


### PR DESCRIPTION
This patch fixes the TypeScript definition of `StoreCreator` to make `preloadedState` optional.

Why? I'll explain.

Here is a TypeScript version of the documented way to create a store:


```js
import { createStore } from 'redux';
import { StoreCreator, install } from 'redux-loop';
import reducer from './reducer';

type ApplicationState = {};
const initialState: ApplicationState = { /* ... */ };

const enhancedCreateStore = createStore as StoreCreator;
const store = enhancedCreateStore(
  reducer, initialState, install<ApplicationState>()
);
```

However, `initialState` is optional in [createStore](https://redux.js.org/api/createstore). This should be possible:

```js
const store = enhancedCreateStore(
  reducer, undefined, install<ApplicationState>()
);
```

Yet it produces an error that looks something like this. The actual error is generated from the redux-loop test suite before my patch.

```
test/typescript/loopReducer.ts:174:3 - error TS2345: Argument of type 'LoopReducer<TodoState, TodoActions>' is not assignable to parameter of type 'LoopReducer<TodoState | undefined, TodoActions>'.
  Type 'TodoState | undefined' is not assignable to type 'TodoState'.
    Type 'undefined' is not assignable to type 'TodoState'.

174   todosReducer, undefined, enhancer
      ~~~~~~~~~~~~
```

It's very cryptic but I've tracked it down to the type definition of StoreCreator, which I've fixed to look more like [that of `redux`](https://github.com/reduxjs/redux/blob/d53364c44b2fb75b59e2c98090b253c103d63c75/index.d.ts#L232-L236).