### PR TITLE
Fix TypeScript tests so they fail for errors 😭

### DIFF
--- a/test/typescript.spec.js
+++ b/test/typescript.spec.js
@@ -1,3 +1,4 @@
+import * as ts from 'typescript'
 import * as tt from 'typescript-definition-tester'
 
 describe('TypeScript definitions', function () {
@@ -5,7 +6,9 @@ describe('TypeScript definitions', function () {
     tt.compileDirectory(
       __dirname + '/typescript',
       fileName => fileName.match(/\.ts$/),
-      () => done()
+      // This matches what's in tsconfig.json
+      { target: ts.ScriptTarget.ES2017 },
+      (error) => done(error)
     )
   })
 })


### PR DESCRIPTION
I noticed that the TypeScript tests aren't working. Here's a patch that should trigger a test failure:

```diff
diff --git a/index.d.ts b/index.d.ts
index fa84b3e..b788e7c 100644
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Action, ActionCreator, AnyAction, StoreEnhancer, Store } from 'redux';
 export interface StoreCreator {
   <S, A extends Action>(
     reducer: LoopReducer<S, A>,
-    preloadedState: S | undefined,
+    preloadedState?: S | undefined,
     enhancer: StoreEnhancer<S>
   ): Store<S>;
 }

```

Only after passing the error to `done()` (which totally [isn't documented correctly](https://github.com/adamcarr/typescript-definition-tester)), I get a test failure:

```
 FAIL  test/typescript.spec.js
  ● Console

    console.log node_modules/typescript-definition-tester/dist/index.js:28
      Global finished

  ● TypeScript definitions › should compile against index.d.ts

    AssertionError: Semantic: /Users/kumar/tmp/redux-loop/index.d.ts (7,5): A required parameter cannot follow an optional parameter.

      at diagnostics.forEach.diagnostic (node_modules/typescript-definition-tester/dist/index.js:17:15)
          at Array.forEach (<anonymous>)
      at handleDiagnostics (node_modules/typescript-definition-tester/dist/index.js:14:17)
      at compile (node_modules/typescript-definition-tester/dist/index.js:29:9)
      at walk (node_modules/typescript-definition-tester/dist/index.js:63:13)
      at next (node_modules/typescript-definition-tester/dist/index.js:82:24)
      at node_modules/typescript-definition-tester/dist/index.js:95:21

Test Suites: 1 failed, 7 passed, 8 total
```

There was an error about some usage of `Promise` which I fixed with some lib configuration. Unfortunately I couldn't find a way to use `tsconfig.json` directly.