### PR TITLE
Better typings for reducers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,16 +10,16 @@ export interface StoreCreator {
 
 export type Loop<S, A extends Action> = [S, CmdType<A>];
 
-export interface LoopReducer<S, A extends Action> {
-  (state: S | undefined, action: AnyAction, ...args: any[]): S | Loop<S, A>;
+export interface LoopReducer<S, A extends Action = AnyAction> {
+  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, A>;
 }
 
-export interface LoopReducerWithDefinedState<S, A extends Action> {
-  (state: S, action: AnyAction, ...args: any[]): S | Loop<S, A>;
+export interface LoopReducerWithDefinedState<S, A extends Action = AnyAction> {
+  (state: S, action: A, ...args: any[]): S | Loop<S, A>;
 }
 
-export interface LiftedLoopReducer<S, A extends Action> {
-  (state: S | undefined, action: AnyAction, ...args: any[]): Loop<S, A>;
+export interface LiftedLoopReducer<S, A extends Action = AnyAction> {
+  (state: S | undefined, action: A, ...args: any[]): Loop<S, A>;
 }
 
 export type CmdSimulation = {


### PR DESCRIPTION
`Reducer` in Redux is defined like so:
```typescript
export type Reducer<S = any, A extends Action = AnyAction> = (
  state: S | undefined,
  action: A
) => S
```
I think it would be better to define `LoopReducer` in a similar way so the action type is taken from the parameter and the parameter has the same default as `Reducer`