### PR TITLE
Add type for Cmd.run's options.testInvariants.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ declare namespace Cmd {
       failActionCreator?: ActionCreator<A>;
       successActionCreator?: ActionCreator<B>;
       forceSync?: boolean;
-      testInvariants? boolean;
+      testInvariants?: boolean;
     }
   ): RunCmd<A>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,7 @@ declare namespace Cmd {
       failActionCreator?: ActionCreator<A>;
       successActionCreator?: ActionCreator<B>;
       forceSync?: boolean;
+      testInvariants? boolean;
     }
   ): RunCmd<A>;
 }


### PR DESCRIPTION
Been using redux-loop extensively and recently introduced TypeScript to one of my projects. I noticed that the type for testInvariants for Cmd.run's options is missing, so I added it. Thanks!