### PR TITLE
feat(ts): improve run signature typings

### DIFF
--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -148,8 +148,8 @@ const rootState: RootState = rootReducer(undefined, {
   text: 'test'
 })[0];
 
-let cmd = Cmd.run(() => {}, {
-  successActionCreator: a => ({type: 'FOO', a: 2*a})
+let cmd = Cmd.run(() => 2, {
+  successActionCreator: (a: number) => ({type: 'FOO', a: 2*a})
 });
 let action: AnyAction = cmd.simulate({success: true, result: 123});
 let listCmd = Cmd.list([cmd, cmd]);


### PR DESCRIPTION
Sorry for the inconvenience, we accidentally closed the [previous pull request](#213) by reseting the forks master to upstream.

We refined the changes from the previous PR incorporating the changes done in 268c98191bff6963795fda166376aa9b14106f19.

This makes sure that the result of the function passed to `run` is compatible with the arguments that the `successActionCreator` receives.