### PR TITLE
Cmd.map() wraps actions send via dispatch()

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -160,7 +160,7 @@ export function executeCmd(cmd, dispatch, getState, loopConfig = {}) {
     case cmdTypes.MAP: {
       const possiblePromise = executeCmd(
         cmd.nestedCmd,
-        dispatch,
+        action => dispatch(cmd.tagger(...cmd.args, action)),
         getState,
         loopConfig
       );

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -521,6 +521,28 @@ describe('Cmds', () => {
           { ...actionCreator2(action2), arg1, arg2 }
         ]);
       });
+
+      function dispatchAction(action) {
+        return Cmd.run(
+          (dispatch) => dispatch(action),
+          {
+            args: [Cmd.dispatch],
+          }
+        );
+      }
+
+      it('runs the actions from async dispatch through the tagger function', () => {
+        let action1 = actionCreator1(123);
+        let subCommand = dispatchAction(action1);
+        let arg1 = 'arg1',
+          arg2 = 'arg2';
+        let cmd = Cmd.map(subCommand, argTagger, arg1, arg2);
+        let result = executeCmd(cmd, dispatch, getState);
+        expect(result).toEqual(null);
+        expect(dispatch).toHaveBeenCalledWith(
+          { ...actionCreator2(action1), arg1, arg2 },
+        );
+      });
     });
 
     describe('Cmd.none', () => {

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -523,12 +523,9 @@ describe('Cmds', () => {
       });
 
       function dispatchAction(action) {
-        return Cmd.run(
-          (dispatch) => dispatch(action),
-          {
-            args: [Cmd.dispatch],
-          }
-        );
+        return Cmd.run(dispatch => dispatch(action), {
+          args: [Cmd.dispatch]
+        });
       }
 
       it('runs the actions from async dispatch through the tagger function', () => {
@@ -539,9 +536,11 @@ describe('Cmds', () => {
         let cmd = Cmd.map(subCommand, argTagger, arg1, arg2);
         let result = executeCmd(cmd, dispatch, getState);
         expect(result).toEqual(null);
-        expect(dispatch).toHaveBeenCalledWith(
-          { ...actionCreator2(action1), arg1, arg2 },
-        );
+        expect(dispatch).toHaveBeenCalledWith({
+          ...actionCreator2(action1),
+          arg1,
+          arg2
+        });
       });
     });
 


### PR DESCRIPTION
This was implemented inconsistently because actions returned from a command would be wrapped with the tagger but actions send through dispatch() would not.

I wrote an example program to demonstrate the problem:
```typescript
import { createStore, Dispatch } from 'redux';
import { Cmd, install, liftState, LoopReducer, loop, StoreCreator } from 'redux-loop';

interface ParentState {
    childState: ChildState;
}

interface ChildState {
    currentPage: number;
}

type ParentAction = { type: 'CHILD_ACTION', payload: { subAction: ChildAction } };

type ChildAction =
    { type: 'NEXT_CLICKED' } |
    { type: 'NEXT_PAGE_ANIMATION_FINISHED' };

const parentReducer: LoopReducer<ParentState, ParentAction> = (state, action) => {
    if (!state) {
        const [ childState ] = liftState(childReducer(undefined, null as any));
        return { childState };
    }

    console.log('parentReducer: processing action:\n', action);

    if (action.type === 'CHILD_ACTION') {
        const [ newChildState, cmd ] = liftState(childReducer(state.childState, action.payload.subAction));
        return loop(
            { ...state, childState: newChildState },
            Cmd.map(cmd, subAction => ({ type: 'CHILD_ACTION', payload: { subAction } })),
        );
    } else {
        console.log('parentReducer: unknown action:', action);
        return state;
    }
};

function scheduleNextPage(dispatch: Dispatch<ChildAction>) {
    setTimeout(() => dispatch({ type: 'NEXT_PAGE_ANIMATION_FINISHED' }), 1000);
}

const childReducer: LoopReducer<ChildState, ChildAction> = (state, action) => {
    if (!state) {
        return { currentPage: 0 };
    }

    if (action.type === 'NEXT_CLICKED') {
        return loop(
            state,
            Cmd.run(scheduleNextPage, { args: [Cmd.dispatch] }),
        );
    } else if (action.type === 'NEXT_PAGE_ANIMATION_FINISHED') {
        return {
            ...state,
            currentPage: state.currentPage + 1,
        };
    } else {
        console.log('childReducer: unknown action type:', action);
        return state;
    }
};

function main() {
    const store = (createStore as StoreCreator)(
        parentReducer,
        undefined,
        install(),
    );

    console.log('Main: simulating NEXT_CLICKED');
    store.dispatch({
        type: 'CHILD_ACTION',
        payload: {
            subAction: { type: 'NEXT_CLICKED' },
        },
    });

    setTimeout(() => {
        console.log('Main: final state:', store.getState());
    }, 2000);
}

main();
```

Compile and run with:
```
tsc test.ts --target es6 --module commonjs && node test.js
```
Output with redux-loop@master:
```
Main: simulating NEXT_CLICKED
parentReducer: processing action:
 { type: 'NEXT_CLICKED',
  payload: { subAction: { type: 'NEXT_CLICKED' } } }
parentReducer: processing action:
 { type: 'NEXT_PAGE_ANIMATION_FINISHED' }
parentReducer: unknown action: { type: 'NEXT_PAGE_ANIMATION_FINISHED' }
Main: final state: { childState: { currentPage: 0 } }
```

Output after fix:
```
Main: simulating NEXT_CLICKED
parentReducer: processing action:
 { type: 'CHILD_ACTION',
  payload: { subAction: { type: 'NEXT_CLICKED' } } }
parentReducer: processing action:
 { type: 'CHILD_ACTION',
  payload: { subAction: { type: 'NEXT_PAGE_ANIMATION_FINISHED' } } }
Main: final state: { childState: { currentPage: 1 } }
```

