### PR TITLE
Simulate always return an array.

### DIFF
--- a/docs/api-docs/cmds.md
+++ b/docs/api-docs/cmds.md
@@ -26,10 +26,10 @@ it doesn't cause any side effects to actually occur.
 
 #### Simulation
 
-Simulating `Cmd.none` always returns null.
+Simulating `Cmd.none` always returns an empty array.
 
 ```js
-expect(Cmd.none.simulate()).toBe(null); //parameter is ignored
+expect(Cmd.none.simulate()).toEqual([]); //parameter is ignored
 ```
 
 #### Examples
@@ -59,12 +59,12 @@ Make sure your action creator is pure if creating an action from a reducer.
 
 #### Simulation
 
-Simulating `action` always returns `actionToDispatch`.
+Simulating `action` always returns an array with a single element: `actionToDispatch`.
 
 ```js
 const action = {type: 'type', foo: 123};
 const cmd = Cmd.action(action);
-expect(cmd.simulate()).toEqual(action); //parameter is ignored
+expect(cmd.simulate()).toEqual([action]); //parameter is ignored
 ```
 
 #### Examples
@@ -127,16 +127,16 @@ because `jasmine.any(Function)` is not a function.
 
 #### Simulation
 
-`run()` cmd simulations pass the result through the correct action creator (depending on the success property passed) and return the resulting action.
+`run()` cmd simulations pass the result through the correct action creator (depending on the success property passed) and return the resulting action in an array.
 
-If there is no corresponding action creator on the cmd object, `null` is returned.
+If there is no corresponding action creator on the cmd object, an empty array is returned.
 
 ```js
 const cmd = Cmd.run(sideEffect, {
   successActionCreator: result => actionCreator(result, 'hard coded');
 });
-expect(cmd.simulate({success: true, result: 123})).toEqual(actionCreator(123, 'hard coded'));
-expect(cmd.simulate({success: false, result: 123})).toBe(null);
+expect(cmd.simulate({success: true, result: 123})).toEqual([actionCreator(123, 'hard coded')]);
+expect(cmd.simulate({success: false, result: 123})).toEqual([]);
 ```
 
 #### Examples
@@ -176,10 +176,10 @@ function reducer(state , action) {
 
   case 'USER_FETCH_SUCCESSFUL':
     return {...state, user: action.user};
-    
+
   case 'USER_FETCH_FAILED':
     return {...state, error: action.error};
-    
+
   default:
     return state;
   }
@@ -197,7 +197,7 @@ function reducer(state , action) {
 
 #### Simulation
 
-Simulating `list()` simulates all of its child cmd objects and returns an array of the results. The resulting array has `null`s filtered out and is flattened.
+Simulating `list()` simulates all of its child cmd objects and returns an array of the results. The resulting array is flattened.
 
 To simulate `list()`, pass an array of parameters to be passed to the corresponding cmd objects for simulation.
 
@@ -279,7 +279,7 @@ encapsulated and actions can be simply directed to the reducer for that slice.
 
 #### Simulation
 
-Simulating a `map` cmd simulates the nested cmd and passes the result through `tagger`. If the result is an array of actions, all of them are passed through `tagger`. If args are provided to the cmd, they are passed to `tagger`.
+Simulating a `map` cmd simulates the nested cmd and passes each of the resulting actions through `tagger`. If args are provided to the cmd, they are passed to `tagger`.
 
 ```js
 const cmd1 = Cmd.run(sideEffect, {
@@ -288,7 +288,7 @@ const cmd1 = Cmd.run(sideEffect, {
 
 const map = Cmd.map(cmd1, actionCreator2, 'extra arg');
 const result = map.simulate({success: true, result: 123});
-expect(result).toEqual(actionCreator2('extra arg', actionCreator(123, 'hard coded')));
+expect(result).toEqual([actionCreator2('extra arg', actionCreator(123, 'hard coded'))]);
 ```
 
 #### Examples

--- a/docs/tutorial/Testing.md
+++ b/docs/tutorial/Testing.md
@@ -62,8 +62,8 @@ expect(cmd).toEqual(Cmd.run(foo, {
   successActionCreator: jasmine.any(Function) //replace with your testing library's equivalent matcher
 }));
 
-expect(cmd.simulate({success: true, result: 123})).toEqual(actionCreator(123, state.blah));
-expect(cmd.simulate({success: false, result: 123})).toBe(null);
+expect(cmd.simulate({success: true, result: 123})).toEqual([actionCreator(123, state.blah)]);
+expect(cmd.simulate({success: false, result: 123})).toEqual([]);
 
 ```
 

--- a/flow-typed/redux-loop_v5.x.x.js
+++ b/flow-typed/redux-loop_v5.x.x.js
@@ -38,7 +38,7 @@ declare module "redux-loop" {
 
   declare export interface NoneCmd {
     type: "NONE";
-    simulate(): null;
+    simulate(): any[];
   }
 
   declare export interface ListCmd<A> {
@@ -52,7 +52,7 @@ declare module "redux-loop" {
   declare export interface ActionCmd<A> {
     type: "ACTION";
     actionToDispatch: A;
-    simulate(): A;
+    simulate(): A[];
   }
 
   declare export interface MapCmd<A, B = any, C = any> {
@@ -60,7 +60,7 @@ declare module "redux-loop" {
     tagger: ((...args:Array<C|B>) => A) | ((subAction: B) => A);
     nestedCmd: CmdType<A>;
     args: Array<C>;
-    simulate(simulations?: CmdSimulation<any> | MultiCmdSimulation): A[] | A | null;
+    simulate(simulations?: CmdSimulation<any> | MultiCmdSimulation): A[];
   }
 
   declare export interface RunCmd<A, B, C> {
@@ -70,7 +70,7 @@ declare module "redux-loop" {
     failActionCreator?: ActionCreator<A, any>;
     successActionCreator?: ActionCreator<A, B>;
     forceSync?: boolean;
-    simulate(simulation: CmdSimulation<B>): A;
+    simulate(simulation: CmdSimulation<B>): A[];
   }
 
   declare export type SequenceCmd<A> = ListCmd<A>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export interface MultiCmdSimulation {
 
 export interface NoneCmd {
   readonly type: 'NONE';
-  simulate(): null;
+  simulate(): {}[];
 }
 
 export interface ListCmd<A extends Action> {
@@ -46,7 +46,7 @@ export interface ListCmd<A extends Action> {
 export interface ActionCmd<A extends Action> {
   readonly type: 'ACTION';
   readonly actionToDispatch: A;
-  simulate(): A;
+  simulate(): A[];
 }
 
 export interface MapCmd<A extends Action> {
@@ -54,7 +54,7 @@ export interface MapCmd<A extends Action> {
   readonly tagger: ActionCreator<A>;
   readonly nestedCmd: CmdType<A>;
   readonly args: any[];
-  simulate(simulations?: CmdSimulation | MultiCmdSimulation): A[] | A | null
+  simulate(simulations?: CmdSimulation | MultiCmdSimulation): A[]
 }
 
 export interface RunCmd<SuccessAction extends Action, FailAction extends Action = Action> {
@@ -64,7 +64,7 @@ export interface RunCmd<SuccessAction extends Action, FailAction extends Action 
   readonly failActionCreator?: ActionCreator<FailAction>;
   readonly successActionCreator?: ActionCreator<SuccessAction>;
   readonly forceSync?: boolean;
-  simulate(simulation: CmdSimulation): SuccessAction | FailAction;
+  simulate(simulation: CmdSimulation): (SuccessAction | FailAction)[];
 }
 
 //deprecated types

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -222,11 +222,11 @@ function executeCmdInternal({
 
 function simulateRun({ result, success }) {
   if (success && this.successActionCreator) {
-    return this.successActionCreator(result);
+    return [this.successActionCreator(result)];
   } else if (!success && this.failActionCreator) {
-    return this.failActionCreator(result);
+    return [this.failActionCreator(result)];
   }
-  return null;
+  return [];
 }
 
 function run(func, options = {}) {
@@ -277,7 +277,7 @@ function run(func, options = {}) {
 }
 
 function simulateAction() {
-  return this.actionToDispatch;
+  return [this.actionToDispatch];
 }
 
 function action(actionToDispatch) {
@@ -299,9 +299,7 @@ function action(actionToDispatch) {
 }
 
 function simulateList(simulations) {
-  return flatten(
-    this.cmds.map((cmd, i) => cmd.simulate(simulations[i])).filter(a => a)
-  );
+  return flatten(this.cmds.map((cmd, i) => cmd.simulate(simulations[i])));
 }
 
 function list(cmds, options = {}) {
@@ -335,14 +333,9 @@ function list(cmds, options = {}) {
 }
 
 function simulateMap(simulation) {
-  let result = this.nestedCmd.simulate(simulation);
-  if (Array.isArray(result)) {
-    return result.map(action => this.tagger(...this.args, action));
-  } else if (result) {
-    return this.tagger(...this.args, result);
-  } else {
-    return null;
-  }
+  return this.nestedCmd
+    .simulate(simulation)
+    .map(action => this.tagger(...this.args, action));
 }
 
 function map(nestedCmd, tagger, ...args) {
@@ -371,7 +364,7 @@ function map(nestedCmd, tagger, ...args) {
 const none = Object.freeze({
   [isCmdSymbol]: true,
   type: cmdTypes.NONE,
-  simulate: () => null
+  simulate: () => []
 });
 
 export default {

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -563,7 +563,7 @@ describe('Cmds', () => {
       describe('with no handlers', () => {
         it('returns null', () => {
           let cmd = Cmd.run(sideEffect);
-          expect(cmd.simulate({ result: 123, success: true })).toBe(null);
+          expect(cmd.simulate({ result: 123, success: true })).toEqual([]);
         });
       });
 
@@ -574,9 +574,9 @@ describe('Cmds', () => {
             failActionCreator: actionCreator2
           });
 
-          expect(cmd.simulate({ result: 123, success: true })).toEqual(
+          expect(cmd.simulate({ result: 123, success: true })).toEqual([
             actionCreator1(123)
-          );
+          ]);
         });
 
         it('returns null if there is no success hanlder', () => {
@@ -584,7 +584,7 @@ describe('Cmds', () => {
             failActionCreator: actionCreator2
           });
 
-          expect(cmd.simulate({ result: 123, success: true })).toBe(null);
+          expect(cmd.simulate({ result: 123, success: true })).toEqual([]);
         });
       });
 
@@ -595,9 +595,9 @@ describe('Cmds', () => {
             failActionCreator: actionCreator2
           });
 
-          expect(cmd.simulate({ result: 123, success: false })).toEqual(
+          expect(cmd.simulate({ result: 123, success: false })).toEqual([
             actionCreator2(123)
-          );
+          ]);
         });
 
         it('returns null if there is no fail hanlder', () => {
@@ -605,7 +605,7 @@ describe('Cmds', () => {
             successActionCreator: actionCreator2
           });
 
-          expect(cmd.simulate({ result: 123, success: false })).toBe(null);
+          expect(cmd.simulate({ result: 123, success: false })).toEqual([]);
         });
       });
     });
@@ -614,7 +614,7 @@ describe('Cmds', () => {
       it('returns the action', () => {
         let action = actionCreator1(123);
         let cmd = Cmd.action(action);
-        expect(cmd.simulate()).toBe(action);
+        expect(cmd.simulate()).toEqual([action]);
       });
     });
 
@@ -705,15 +705,15 @@ describe('Cmds', () => {
           successActionCreator: actionCreator1
         });
         let cmd = Cmd.map(runCmd, noArgTagger);
-        expect(cmd.simulate({ success: true, result: 123 })).toEqual(
+        expect(cmd.simulate({ success: true, result: 123 })).toEqual([
           noArgTagger(actionCreator1(123))
-        );
+        ]);
       });
 
       it('returns null if the nested cmd simulates to null', () => {
         let runCmd = Cmd.run(sideEffect);
         let cmd = Cmd.map(runCmd, noArgTagger);
-        expect(cmd.simulate({ success: true, result: 123 })).toBe(null);
+        expect(cmd.simulate({ success: true, result: 123 })).toEqual([]);
       });
 
       it('passes the args through to the tagger if there are args', () => {
@@ -721,9 +721,9 @@ describe('Cmds', () => {
           successActionCreator: actionCreator1
         });
         let cmd = Cmd.map(runCmd, argTagger, 456, 789);
-        expect(cmd.simulate({ success: true, result: 123 })).toEqual(
+        expect(cmd.simulate({ success: true, result: 123 })).toEqual([
           argTagger(456, 789, actionCreator1(123))
-        );
+        ]);
       });
 
       describe('when the nested simulation returns an array', () => {
@@ -765,7 +765,7 @@ describe('Cmds', () => {
 
     describe('Cmd.none', () => {
       it('returns null', () => {
-        expect(Cmd.none.simulate({ success: true, result: 123 })).toBe(null);
+        expect(Cmd.none.simulate({ success: true, result: 123 })).toEqual([]);
       });
     });
   });

--- a/test/flow/loopReducer.js
+++ b/test/flow/loopReducer.js
@@ -126,11 +126,11 @@ let cmd = Cmd.run(() => Promise.resolve(1), {
 });
 
 // Able to detect errors in result
-let action = cmd.simulate({success: true, result: 123});
+let actions = cmd.simulate({success: true, result: 123});
 
 // Not able to detect error in result
 let listCmd = Cmd.list([cmd, cmd]);
-let actions = listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
+actions = listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
 let nestedListCmd = Cmd.list([cmd, listCmd]);
 let flattenedActions = nestedListCmd.simulate([
   {success: true, result: 123},

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -163,9 +163,9 @@ const rootState: RootState = rootReducer(undefined, {
 let cmd = Cmd.run(() => 1, {
   successActionCreator: (a: number) => ({type: 'FOO', a: 2*a})
 });
-let action: AnyAction = cmd.simulate({success: true, result: 123});
+let actions: AnyAction[] = cmd.simulate({success: true, result: 123});
 let listCmd = Cmd.list([cmd, cmd]);
-let actions: AnyAction[] = listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
+actions= listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
 let nestedListCmd = Cmd.list([cmd, listCmd]);
 let flattenedActions: AnyAction[] = nestedListCmd.simulate([
   {success: true, result: 123},


### PR DESCRIPTION
So we don't always have to check the result with Array.isArray() and check if it is null.

This will be a breaking change, so let's do it now. I think it makes the API more consistent.