### PR TITLE
Adjust TypeScript definition for places where actions may not be dispatched

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,8 +36,20 @@
     "no-unused-vars": ["error", {"ignoreRestSiblings": true, "args": "after-used" }],
     "strict": "error",
     "prettier/prettier": ["error", {
-      singleQuote: true,
-      tabWidth: 2
+      "singleQuote": true,
+      "tabWidth": 2
     }]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended",
+        "prettier/@typescript-eslint"
+      ],
+      "plugins": [
+        "@typescript-eslint"
+      ]
+    }
+  ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 import { Action, ActionCreator, AnyAction, StoreEnhancer, Store } from 'redux';
 
+export type UnknownAction = AnyAction | never;
+
 export interface StoreCreator {
   <S, A extends Action>(
     reducer: LoopReducer<S, A>,
@@ -79,8 +81,6 @@ export interface RunCmd<
   readonly forceSync?: boolean;
   simulate(simulation: CmdSimulation): SuccessAction | FailAction;
 }
-
-type UnknownAction = AnyAction | never;
 
 export type CmdType =
   | ActionCmd<UnknownAction>
@@ -188,18 +188,18 @@ export namespace Cmd {
   ): RunCmd<SuccessAction, FailAction>;
 }
 
-export type ReducerMapObject<S, A extends Action = Action> = {
+export type ReducersMapObject<S, A extends Action = AnyAction> = {
   [K in keyof S]: LoopReducer<S[K], A>;
 };
 
 export function combineReducers<S, A extends Action = AnyAction>(
-  reducers: ReducerMapObject<S, A>
+  reducers: ReducersMapObject<S, A>
 ): LiftedLoopReducer<S, A>;
 
 export function mergeChildReducers<S>(
   parentResult: S | Loop<S>,
   action: AnyAction,
-  childMap: ReducerMapObject<S>
+  childMap: ReducersMapObject<S>
 ): Loop<S>;
 
 export function reduceReducers<S>(
@@ -212,13 +212,10 @@ export function reduceReducers<S, A extends Action>(
   ...reducers: Array<LoopReducerWithDefinedState<S, A>>
 ): LiftedLoopReducer<S, A>;
 
-export function liftState<S, A extends Action>(state: S | Loop<S>): Loop<S>;
+export function liftState<S>(state: S | Loop<S>): Loop<S>;
 
 export function isLoop(test: any): boolean;
 
 export function getModel<S>(loop: S | Loop<S>): S;
 
-export function getCmd<A extends Action, B extends Action = never>(
-  a: any
-): CmdType | null;
 export function getCmd(a: any): CmdType | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,9 +130,9 @@ export namespace Cmd {
       : T[K];
   };
 
-  export type PromiseResult<T> = T extends Promise<infer U> ? U : T;
-
   type RunFunc = (...args: any[]) => Promise<any> | any;
+
+  export type PromiseResult<T> = T extends Promise<infer U> ? U : T;
 
   export type RunOptions<
     Func extends RunFunc,
@@ -157,16 +157,13 @@ export namespace Cmd {
     >
   ): RunCmd<never, never>;
 
-  export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action
-  >(
+  export function run<Func extends RunFunc, SuccessAction extends Action>(
     f: Func,
     options: Omit<RunOptions<Func, SuccessAction>, 'failActionCreator'>
   ): RunCmd<SuccessAction, never>;
 
   export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
+    Func extends RunFunc,
     FailAction extends Action,
     FailReason = unknown
   >(
@@ -178,7 +175,7 @@ export namespace Cmd {
   ): RunCmd<never, FailAction>;
 
   export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
+    Func extends RunFunc,
     SuccessAction extends Action,
     FailAction extends Action,
     FailReason = unknown

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,14 +188,14 @@ export namespace Cmd {
 }
 
 export type ReducerMapObject<S, A extends Action = Action> = {
-  [K in keyof S]: LoopReducer<S[K]>;
+  [K in keyof S]: LoopReducer<S[K], A>;
 };
 
 export function combineReducers<S>(
   reducers: ReducerMapObject<S, any>
 ): LiftedLoopReducer<S, any>;
 
-export function combineReducers<S, A extends Action = AnyAction>(
+export function combineReducers<S, A extends Action>(
   reducers: ReducerMapObject<S, A>
 ): LiftedLoopReducer<S, A>;
 
@@ -210,7 +210,7 @@ export function reduceReducers<S>(
   ...reducers: Array<LoopReducerWithDefinedState<S, any>>
 ): LiftedLoopReducer<S, any>;
 
-export function reduceReducers<S, A extends Action = AnyAction>(
+export function reduceReducers<S, A extends Action>(
   initialReducer: LoopReducer<S, A>,
   ...reducers: Array<LoopReducerWithDefinedState<S, A>>
 ): LiftedLoopReducer<S, A>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,16 +10,16 @@ export interface StoreCreator {
 
 export type Loop<S, A extends Action = never> = [S, CmdType<A>];
 
-export interface LoopReducer<S, A extends Action = AnyAction> {
-  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, A>;
+export interface LoopReducer<S, A extends Action = AnyAction, B extends Action = A> {
+  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, B>;
 }
 
-export interface LoopReducerWithDefinedState<S, A extends Action = AnyAction> {
-  (state: S, action: A, ...args: any[]): S | Loop<S, A>;
+export interface LoopReducerWithDefinedState<S, A extends Action = AnyAction, B extends Action = A> {
+  (state: S, action: A, ...args: any[]): S | Loop<S, B>;
 }
 
-export interface LiftedLoopReducer<S, A extends Action = AnyAction> {
-  (state: S | undefined, action: A, ...args: any[]): Loop<S, A>;
+export interface LiftedLoopReducer<S, A extends Action = AnyAction, B extends Action = A> {
+  (state: S | undefined, action: A, ...args: any[]): Loop<S, B>;
 }
 
 export type CmdSimulation = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface StoreCreator {
   ): Store<S>;
 }
 
-type WithDefaultActionHandling<T> = T | Action<'ENFORCE_DEFAULT_HANDLING'>;
+type WithDefaultActionHandling<T extends AnyAction> = T | Action<'@@REDUX_LOOP/ENFORCE_DEFAULT_HANDLING'>;
 
 export type Loop<S, A extends Action = never> = [S, CmdType<A>];
 
@@ -142,10 +142,10 @@ export namespace Cmd {
 
   export function run<
     Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action = never,
+    SuccessAction extends Action,
     >(
     f: Func,
-    options?: {
+    options: {
       args?: ArgOrSymbol<Parameters<Func>>;
       successActionCreator: (value: PromiseResult<ReturnType<Func>>) => SuccessAction;
       forceSync?: boolean;
@@ -155,10 +155,10 @@ export namespace Cmd {
 
   export function run<
     Func extends (...args: any[]) => Promise<any> | any,
-    FailAction extends Action = never,
+    FailAction extends Action,
     >(
     f: Func,
-    options?: {
+    options: {
       args?: ArgOrSymbol<Parameters<Func>>;
       failActionCreator: (error: any) => FailAction;
       forceSync?: boolean;
@@ -172,7 +172,7 @@ export namespace Cmd {
     FailAction extends Action,
     >(
     f: Func,
-    options?: {
+    options: {
       args?: ArgOrSymbol<Parameters<Func>>;
       failActionCreator: (error: any) => FailAction;
       successActionCreator: (value: PromiseResult<ReturnType<Func>>) => SuccessAction;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,12 @@ export interface StoreCreator {
 
 export type Loop<S, A extends Action = never> = [S, CmdType<A>];
 
-export interface LoopReducer<S, A extends Action = AnyAction, B extends Action = A> {
-  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, B>;
+export interface LoopReducerDeprecated<S, A extends Action = AnyAction> {
+  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, A>;
+}
+
+export interface LoopReducer<S, LoopActions extends Action = never> {
+  (state: S | undefined, action: AnyAction, ...args: any[]): S | Loop<S, LoopActions>;
 }
 
 export interface LoopReducerWithDefinedState<S, A extends Action = AnyAction, B extends Action = A> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,53 +131,32 @@ export namespace Cmd {
   }
   export type PromiseResult<T> = T extends Promise<infer U> ? U : T;
 
-  export function run<Func extends (...args: any[]) => Promise<any> | any>(
+  type RunFunc = (...args: any[]) => Promise<any> | any;
+
+  type RunOptions<Func extends RunFunc> = {
+    args?: ArgOrSymbol<Parameters<Func>>;
+    forceSync?: boolean;
+    testInvariants?: boolean;
+  }
+
+  export function run<Func extends RunFunc>(
     f: Func,
-    options?: {
-      args?: ArgOrSymbol<Parameters<Func>>;
-      forceSync?: boolean;
-      testInvariants?: boolean;
-    },
+    options?: RunOptions<Func>,
   ): RunCmd;
 
   export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action,
+    Func extends RunFunc,
+    SuccessAction extends Action = never,
+    FailAction extends Action = never,
     >(
     f: Func,
-    options: {
-      args?: ArgOrSymbol<Parameters<Func>>;
-      successActionCreator: (value: PromiseResult<ReturnType<Func>>) => SuccessAction;
-      forceSync?: boolean;
-      testInvariants?: boolean;
-    },
-  ): RunCmd<SuccessAction, never>;
-
-  export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
-    FailAction extends Action,
-    >(
-    f: Func,
-    options: {
-      args?: ArgOrSymbol<Parameters<Func>>;
-      failActionCreator: (error: any) => FailAction;
-      forceSync?: boolean;
-      testInvariants?: boolean;
-    },
-  ): RunCmd<never, FailAction>;
-
-  export function run<
-    Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action,
-    FailAction extends Action,
-    >(
-    f: Func,
-    options: {
-      args?: ArgOrSymbol<Parameters<Func>>;
-      failActionCreator: (error: any) => FailAction;
-      successActionCreator: (value: PromiseResult<ReturnType<Func>>) => SuccessAction;
-      forceSync?: boolean;
-      testInvariants?: boolean;
+    options: RunOptions<Func> & {
+      failActionCreator: [FailAction] extends [never]
+        ? undefined
+        : (error: any) => FailAction;
+      successActionCreator: [SuccessAction] extends [never]
+        ? undefined
+        : (value: PromiseResult<ReturnType<Func>>) => SuccessAction;
     },
   ): RunCmd<SuccessAction, FailAction>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,22 +8,20 @@ export interface StoreCreator {
   ): Store<S>;
 }
 
+type WithDefaultActionHandling<T> = T | Action<'ENFORCE_DEFAULT_HANDLING'>;
+
 export type Loop<S, A extends Action = never> = [S, CmdType<A>];
 
-export interface LoopReducerDeprecated<S, A extends Action = AnyAction> {
-  (state: S | undefined, action: A, ...args: any[]): S | Loop<S, A>;
+export interface LoopReducer<S, ReducerActions extends Action = AnyAction, LoopActions extends Action = never> {
+  (state: S | undefined, action: WithDefaultActionHandling<ReducerActions>, ...args: any[]): S | Loop<S, LoopActions>;
 }
 
-export interface LoopReducer<S, LoopActions extends Action = never> {
-  (state: S | undefined, action: AnyAction, ...args: any[]): S | Loop<S, LoopActions>;
+export interface LoopReducerWithDefinedState<S, ReducerActions extends Action = AnyAction, LoopActions extends Action = never> {
+  (state: S, action: WithDefaultActionHandling<ReducerActions>, ...args: any[]): S | Loop<S, LoopActions>;
 }
 
-export interface LoopReducerWithDefinedState<S, A extends Action = AnyAction, B extends Action = A> {
-  (state: S, action: A, ...args: any[]): S | Loop<S, B>;
-}
-
-export interface LiftedLoopReducer<S, A extends Action = AnyAction, B extends Action = A> {
-  (state: S | undefined, action: A, ...args: any[]): Loop<S, B>;
+export interface LiftedLoopReducer<S, ReducerActions extends Action = AnyAction, LoopActions extends Action = never> {
+  (state: S | undefined, action: WithDefaultActionHandling<ReducerActions>, ...args: any[]): Loop<S, LoopActions>;
 }
 
 export type CmdSimulation = {
@@ -61,7 +59,7 @@ export interface MapCmd<A extends Action = never> {
   simulate(simulations?: CmdSimulation | MultiCmdSimulation): A[] | A | null
 }
 
-export interface RunCmd<SuccessAction extends Action = never, FailAction extends Action = Action> {
+export interface RunCmd<SuccessAction extends Action = never, FailAction extends Action = never> {
   readonly type: 'RUN';
   readonly func: Function;
   readonly args?: any[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface StoreCreator {
   ): Store<S>;
 }
 
-export type Loop<S, A extends Action> = [S, CmdType<A>];
+export type Loop<S, A extends Action = never> = [S, CmdType<A>];
 
 export interface LoopReducer<S, A extends Action = AnyAction> {
   (state: S | undefined, action: A, ...args: any[]): S | Loop<S, A>;
@@ -35,7 +35,7 @@ export interface NoneCmd {
   simulate(): null;
 }
 
-export interface ListCmd<A extends Action> {
+export interface ListCmd<A extends Action = never> {
   readonly type: 'LIST';
   readonly cmds: CmdType<A>[];
   readonly sequence?: boolean;
@@ -49,7 +49,7 @@ export interface ActionCmd<A extends Action> {
   simulate(): A;
 }
 
-export interface MapCmd<A extends Action> {
+export interface MapCmd<A extends Action = never> {
   readonly type: 'MAP';
   readonly tagger: ActionCreator<A>;
   readonly nestedCmd: CmdType<A>;
@@ -57,7 +57,7 @@ export interface MapCmd<A extends Action> {
   simulate(simulations?: CmdSimulation | MultiCmdSimulation): A[] | A | null
 }
 
-export interface RunCmd<SuccessAction extends Action, FailAction extends Action = Action> {
+export interface RunCmd<SuccessAction extends Action = never, FailAction extends Action = Action> {
   readonly type: 'RUN';
   readonly func: Function;
   readonly args?: any[];
@@ -68,11 +68,11 @@ export interface RunCmd<SuccessAction extends Action, FailAction extends Action 
 }
 
 //deprecated types
-export type SequenceCmd<A extends Action> = ListCmd<A>;
-export type BatchCmd<A extends Action> = ListCmd<A>;
+export type SequenceCmd<A extends Action = never> = ListCmd<A>;
+export type BatchCmd<A extends Action = never> = ListCmd<A>;
 
 
-export type CmdType<A extends Action> =
+export type CmdType<A extends Action = never> =
   | ActionCmd<A>
   | ListCmd<A>
   | MapCmd<A>
@@ -87,7 +87,7 @@ export interface LoopConfig {
 
 export function install<S>(config?: LoopConfig): StoreEnhancer<S>;
 
-export function loop<S, A extends Action>(
+export function loop<S, A extends Action = never>(
   state: S,
   cmd: CmdType<A>
 ): Loop<S, A>;
@@ -100,10 +100,10 @@ export namespace Cmd {
   export type GetState = <S>() => S;
 
   export function action<A extends Action>(action: A): ActionCmd<A>;
-  export function batch<A extends Action>(cmds: CmdType<A>[]): BatchCmd<A>;
-  export function sequence<A extends Action>(cmds: CmdType<A>[]): SequenceCmd<A>;
+  export function batch<A extends Action = never>(cmds: CmdType<A>[]): BatchCmd<A>;
+  export function sequence<A extends Action = never>(cmds: CmdType<A>[]): SequenceCmd<A>;
 
-  export function list<A extends Action>(
+  export function list<A extends Action = never>(
     cmds: CmdType<A>[],
     options?: {
       batch?: boolean;
@@ -112,7 +112,7 @@ export namespace Cmd {
     }
   ): ListCmd<A>;
 
-  export function map<A extends Action, B extends Action>(
+  export function map<A extends Action, B extends Action = never>(
     cmd: CmdType<B>,
     tagger: (subAction: B) => A,
     args?: any[]
@@ -131,8 +131,8 @@ export namespace Cmd {
 
   export function run<
     Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action,
-    FailAction extends Action,
+    SuccessAction extends Action = never,
+    FailAction extends Action = never,
     >(
     f: Func,
     options?: {
@@ -172,4 +172,4 @@ export function isLoop(test: any): boolean;
 
 export function getModel<S>(loop: S | Loop<S, AnyAction>): S;
 
-export function getCmd<A extends Action>(a: any): CmdType<A> | null;
+export function getCmd<A extends Action = never>(a: any): CmdType<A> | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,18 +69,12 @@ export interface RunCmd<SuccessAction extends Action = never, FailAction extends
   simulate(simulation: CmdSimulation): SuccessAction | FailAction;
 }
 
-//deprecated types
-export type SequenceCmd<A extends Action = never> = ListCmd<A>;
-export type BatchCmd<A extends Action = never> = ListCmd<A>;
-
 export type CmdType<A extends Action = never> =
   | ActionCmd<A>
   | ListCmd<A>
   | MapCmd<A>
   | NoneCmd
-  | RunCmd<A>
-  | BatchCmd<A>
-  | SequenceCmd<A>;
+  | RunCmd<A>;
 
 export interface LoopConfig {
   readonly DONT_LOG_ERRORS_ON_HANDLED_FAILURES: boolean;
@@ -101,9 +95,7 @@ export namespace Cmd {
   export type GetState = <S>() => S;
 
   export function action<A extends Action>(action: A): ActionCmd<A>;
-  export function batch<A extends Action = never>(cmds: CmdType<A>[]): BatchCmd<A>;
-  export function sequence<A extends Action = never>(cmds: CmdType<A>[]): SequenceCmd<A>;
-
+  
   export function list(
     cmds: CmdType[],
     options?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,23 +106,13 @@ export namespace Cmd {
 
   export function action<A extends Action>(action: A): ActionCmd<A>;
 
-  export function list(
-    cmds: CmdType[],
-    options?: {
-      batch?: boolean;
-      sequence?: boolean;
-      testInvariants?: boolean;
-    }
-  ): ListCmd;
+  export type ListOptions = {
+    batch?: boolean;
+    sequence?: boolean;
+    testInvariants?: boolean;
+  };
 
-  export function list(
-    cmds: CmdType[],
-    options?: {
-      batch?: boolean;
-      sequence?: boolean;
-      testInvariants?: boolean;
-    }
-  ): ListCmd;
+  export function list(cmds: CmdType[], options?: ListOptions): ListCmd;
 
   export function map<A extends Action, B extends Action>(
     cmd: CmdType,
@@ -143,7 +133,7 @@ export namespace Cmd {
 
   type RunFunc = (...args: any[]) => Promise<any> | any;
 
-  type RunOptions<
+  export type RunOptions<
     Func extends RunFunc,
     SuccessAction extends Action = never,
     FailAction extends Action = never,
@@ -188,8 +178,8 @@ export namespace Cmd {
 
   export function run<
     Func extends (...args: any[]) => Promise<any> | any,
-    SuccessAction extends Action = never,
-    FailAction extends Action = never,
+    SuccessAction extends Action,
+    FailAction extends Action,
     FailReason = unknown
   >(
     f: Func,
@@ -197,19 +187,28 @@ export namespace Cmd {
   ): RunCmd<SuccessAction, FailAction>;
 }
 
-export type ReducerMapObject<S> = {
+export type ReducerMapObject<S, A extends Action = Action> = {
   [K in keyof S]: LoopReducer<S[K]>;
 };
 
 export function combineReducers<S>(
-  reducers: ReducerMapObject<S>
-): LiftedLoopReducer<S>;
+  reducers: ReducerMapObject<S, any>
+): LiftedLoopReducer<S, any>;
+
+export function combineReducers<S, A extends Action = AnyAction>(
+  reducers: ReducerMapObject<S, A>
+): LiftedLoopReducer<S, A>;
 
 export function mergeChildReducers<S>(
   parentResult: S | Loop<S>,
   action: AnyAction,
   childMap: ReducerMapObject<S>
 ): Loop<S>;
+
+export function reduceReducers<S>(
+  initialReducer: LoopReducer<S, any>,
+  ...reducers: Array<LoopReducerWithDefinedState<S, any>>
+): LiftedLoopReducer<S, any>;
 
 export function reduceReducers<S, A extends Action = AnyAction>(
   initialReducer: LoopReducer<S, A>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,7 @@ export type CmdType =
 
 export interface LoopConfig {
   readonly DONT_LOG_ERRORS_ON_HANDLED_FAILURES: boolean;
+  readonly ENABLE_THUNK_MIGRATION: boolean;
 }
 
 export function install<S>(config?: LoopConfig): StoreEnhancer<S>;
@@ -191,11 +192,7 @@ export type ReducerMapObject<S, A extends Action = Action> = {
   [K in keyof S]: LoopReducer<S[K], A>;
 };
 
-export function combineReducers<S>(
-  reducers: ReducerMapObject<S, any>
-): LiftedLoopReducer<S, any>;
-
-export function combineReducers<S, A extends Action>(
+export function combineReducers<S, A extends Action = AnyAction>(
   reducers: ReducerMapObject<S, A>
 ): LiftedLoopReducer<S, A>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,10 +211,10 @@ export function mergeChildReducers<S>(
   childMap: ReducerMapObject<S>
 ): Loop<S>;
 
-export function reduceReducers<S>(
-  initialReducer: LoopReducer<S>,
-  ...reducers: Array<LoopReducerWithDefinedState<S>>
-): LiftedLoopReducer<S>;
+export function reduceReducers<S, A extends Action = AnyAction>(
+  initialReducer: LoopReducer<S, A>,
+  ...reducers: Array<LoopReducerWithDefinedState<S, A>>
+): LiftedLoopReducer<S, A>;
 
 export function liftState<S, A extends Action>(state: S | Loop<S>): Loop<S>;
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@babel/plugin-transform-property-literals": "^7.2.0",
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
+    "@typescript-eslint/eslint-plugin": "^3.2.0",
+    "@typescript-eslint/parser": "^3.2.0",
     "babel-eslint": "^10.0.1",
     "cross-env": "^5.0.5",
     "eslint": "^6.1.0",

--- a/test/typescript/loopReducer.ts
+++ b/test/typescript/loopReducer.ts
@@ -1,129 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   Cmd,
   combineReducers,
   install,
   loop,
-  Loop,
-  LiftedLoopReducer,
   liftState,
   LoopReducer,
-  StoreCreator,
+  StoreCreator
 } from '../../index';
-import { AnyAction, createStore } from 'redux';
+import { Action, AnyAction, createStore } from 'redux';
 
-const FETCH_FOO_REQUEST = 'FETCH_FOO_REQUEST'
-const FETCH_FOO_SUCCESS = 'FETCH_FOO_SUCCESS'
-const FETCH_FOO_FAILURE = 'FETCH_FOO_FAILURE'
+const FETCH_FOO_REQUEST = 'FETCH_FOO_REQUEST';
+const FETCH_FOO_SUCCESS = 'FETCH_FOO_SUCCESS';
+const FETCH_FOO_FAILURE = 'FETCH_FOO_FAILURE';
+const NOOP = 'NOOP';
+const UPDATE_NESTED_COUNTER = 'UPDATE_NESTED_COUNTER';
+const ADD_TODO = 'ADD_TODO';
 
 type TodoState = { todos: string[]; nestedCounter: number };
 
 const initialTodoState: TodoState = { todos: [], nestedCounter: 0 };
 
-type TodoActions =
-  | {
-      type: 'ADD_TODO';
-      text: string;
-    }
-  | { type: 'NOOP' }
-  | { type: 'UPDATE_NESTED_COUNTER'; subAction: CounterActions }
-  | IFetchFooRequest
-  | IFetchFooSuccess
-  | IFetchFooFailure
+type IAddTodo = Action<typeof ADD_TODO> & {
+  text: string;
+};
 
-const noop = (): TodoActions => ({
-  type: 'NOOP'
+type INoopAction = Action<typeof NOOP>;
+
+type IUpdateNestedCounter = Action<typeof UPDATE_NESTED_COUNTER> & {
+  subAction: CounterActions;
+};
+
+type TodoReducerActions =
+  | IAddTodo
+  | INoopAction
+  | IUpdateNestedCounter
+  | IFetchFooRequest;
+
+const noop = (): TodoReducerActions => ({
+  type: NOOP
 });
 
-const updateNestedCounter = (subAction: CounterActions): TodoActions => ({
-  type: 'UPDATE_NESTED_COUNTER',
+const updateNestedCounter = (
+  subAction: CounterActions
+): TodoReducerActions => ({
+  type: UPDATE_NESTED_COUNTER,
   subAction
 });
 
 interface IFetchFooRequest {
-  type: typeof FETCH_FOO_REQUEST
+  type: typeof FETCH_FOO_REQUEST;
 }
 
 interface IFetchFooSuccess {
-  type: typeof FETCH_FOO_SUCCESS
+  type: typeof FETCH_FOO_SUCCESS;
 }
 
-const fetchFooSuccess = (result: string): IFetchFooSuccess => ({
-  type: FETCH_FOO_SUCCESS,
-})
+const fetchFooSuccess = (_result: string): IFetchFooSuccess => ({
+  type: FETCH_FOO_SUCCESS
+});
 
 interface IFetchFooFailure {
-  type: typeof FETCH_FOO_FAILURE
+  type: typeof FETCH_FOO_FAILURE;
 }
 
 class CustomError extends Error {
-  public prop = 'myprop';
+  prop = 'myprop';
 }
 
-const fetchFooFailure = (err: CustomError): IFetchFooFailure => ({
-  type: FETCH_FOO_FAILURE,
-})
+const fetchFooFailure = (_err: CustomError): IFetchFooFailure => ({
+  type: FETCH_FOO_FAILURE
+});
 
-const apiFetchFoo = () => Promise.resolve("foo")
-
-const todosReducer: LoopReducer<TodoState, TodoActions> = (
-  state: TodoState = initialTodoState,
-  action: AnyAction
-) => {
-  switch (action.type) {
-    case 'ADD_TODO':
-      return loop(
-        { ...state, todos: [...state.todos, action.text] },
-        Cmd.list([Cmd.none, Cmd.action(noop())])
-      );
-    case 'NOOP':
-      return state;
-    case 'UPDATE_NESTED_COUNTER':
-      const [model, cmd] = liftState(
-        counterReducer(state.nestedCounter, action.subAction)
-      );
-      return loop(
-        { ...state, nestedCounter: model },
-        Cmd.map(cmd, updateNestedCounter)
-      );
-    case FETCH_FOO_REQUEST:
-      return loop(
-        state,
-        Cmd.run(apiFetchFoo, {
-          successActionCreator: fetchFooSuccess,
-          failActionCreator: fetchFooFailure,
-        })
-      )
-    default:
-      return loop(
-        state,
-        Cmd.list([
-          Cmd.none,
-          Cmd.run(console.log, { args: ['log this', Cmd.getState] }),
-          Cmd.run(dispatchNoop, { args: [Cmd.dispatch] }),
-          Cmd.run(getState, { args: [1, Cmd.getState] }),
-          Cmd.run(typedArgs, { args: [1, 'a', { n: 2 }] })
-        ], {sequence: true})
-      );
-  }
-};
+const apiFetchFoo = () => Promise.resolve('foo');
 
 const dispatchNoop = (dispatch: Cmd.Dispatch): void => {
   dispatch(noop());
 };
 
-const getState = (n: number, getState: Cmd.GetState): void => {
-  const s = getState();
+const getState = (_n: number, getState: Cmd.GetState): void => {
+  getState();
 };
 
-const typedArgs = (a: number, b: string, c: { n: number }) => {};
-
-const todoState: TodoState = <TodoState>todosReducer(
-  { todos: [], nestedCounter: 0 },
-  {
-    type: 'ADD_TODO',
-    text: 'test'
-  }
-);
+const typedArgs = (_a: number, _b: string, _c: { n: number }) => {
+  // intentionally empty
+};
 
 type CounterState = number;
 
@@ -143,45 +104,111 @@ const counterReducer: LoopReducer<CounterState, CounterActions> = (
   }
 };
 
+function updateNestedCounterHandler(action: AnyAction, state: TodoState) {
+  const [model, cmd] = liftState(
+    counterReducer(state.nestedCounter, action.subAction)
+  );
+  return loop(
+    { ...state, nestedCounter: model },
+    Cmd.map(cmd, updateNestedCounter)
+  );
+}
+
+const todosReducer: LoopReducer<TodoState, TodoReducerActions> = (
+  state = initialTodoState,
+  action
+) => {
+  switch (action.type) {
+    case ADD_TODO:
+      return loop(
+        { ...state, todos: [...state.todos, action.text] },
+        Cmd.list([Cmd.none, Cmd.action(noop())])
+      );
+    case NOOP:
+      return state;
+    case UPDATE_NESTED_COUNTER:
+      return updateNestedCounterHandler(action, state);
+    case FETCH_FOO_REQUEST:
+      return loop(
+        state,
+        Cmd.run<
+          () => Promise<string>,
+          IFetchFooSuccess,
+          IFetchFooFailure,
+          CustomError
+        >(apiFetchFoo, {
+          successActionCreator: fetchFooSuccess,
+          failActionCreator: fetchFooFailure
+        })
+      );
+    default:
+      return loop(
+        state,
+        Cmd.list(
+          [
+            Cmd.none,
+            Cmd.run(console.log, { args: ['log this', Cmd.getState] }),
+            Cmd.run(dispatchNoop, { args: [Cmd.dispatch] }),
+            Cmd.run(getState, { args: [1, Cmd.getState] }),
+            Cmd.run(typedArgs, { args: [1, 'a', { n: 2 }] })
+          ],
+          { sequence: true }
+        )
+      );
+  }
+};
+
+const todoState: TodoState = <TodoState>todosReducer(
+  { todos: [], nestedCounter: 0 },
+  {
+    type: ADD_TODO,
+    text: 'test'
+  }
+);
+
+type RootReducerActions = TodoReducerActions | CounterActions;
+
 type RootState = {
   todos: TodoState;
   counter: CounterState;
 };
 
-type RootAction = TodoActions | CounterActions;
-
-const rootReducer = combineReducers<RootState, RootAction>({
+const rootReducer = combineReducers<RootState>({
   todos: todosReducer,
   counter: counterReducer
 });
 
 const rootState: RootState = rootReducer(undefined, {
-  type: 'ADD_TODO',
+  type: ADD_TODO,
   text: 'test'
 })[0];
 
-let cmd = Cmd.run(() => 1, {
-  successActionCreator: (a: number) => ({type: 'FOO', a: 2*a})
+const cmd = Cmd.run(() => 1, {
+  successActionCreator: (a: number) => ({ type: 'FOO', a: 2 * a })
 });
-let action: AnyAction = cmd.simulate({success: true, result: 123});
-let listCmd = Cmd.list([cmd, cmd]);
-let actions: AnyAction[] = listCmd.simulate([{success: true, result: 123}, {success: false, result: 456}]);
-let nestedListCmd = Cmd.list([cmd, listCmd]);
-let flattenedActions: AnyAction[] = nestedListCmd.simulate([
-  {success: true, result: 123},
-  [
-    {success: true, result: 456},
-    {success: true, result: 789},
-  ]
+const action: AnyAction = cmd.simulate({ success: true, result: 123 });
+const listCmd = Cmd.list([cmd, cmd]);
+const actions: AnyAction[] = listCmd.simulate([
+  { success: true, result: 123 },
+  { success: false, result: 456 }
+]);
+const nestedListCmd = Cmd.list([cmd, listCmd]);
+const flattenedActions: AnyAction[] = nestedListCmd.simulate([
+  { success: true, result: 123 },
+  [{ success: true, result: 456 }, { success: true, result: 789 }]
 ]);
 
 const enhancedCreateStore = createStore as StoreCreator;
 const enhancer = install<TodoState>();
 
 const storeWithPreloadedState = enhancedCreateStore(
-  todosReducer, initialTodoState, enhancer
+  todosReducer,
+  initialTodoState,
+  enhancer
 );
 
 const storeWithoutPreloadedState = enhancedCreateStore(
-  todosReducer, undefined, enhancer
+  todosReducer,
+  undefined,
+  enhancer
 );

--- a/test/typescript/reduce-reducers.ts
+++ b/test/typescript/reduce-reducers.ts
@@ -21,43 +21,47 @@ const initialState: ReducedState = {
   mult: 2
 };
 
-type ChangeAction = Action<'change'> & {
+type AddAction = Action<'add'> & {
   value: number;
 };
 
-type StuffAction = Action<'stuff'> & {
-  value: string;
+type MultiplyAction = Action<'multiply'> & {
+  value: number;
 };
 
-type ReducedActions = ChangeAction | StuffAction;
-
-const addReducer: LoopReducer<ReducedState, ReducedActions> = (
+const addReducer: LoopReducer<ReducedState, AddAction> = (
   state = initialState,
   action
 ) => {
-  if (action.type === 'change') {
+  if (action.type === 'add') {
     return { ...state, add: state.add + action.value };
   }
   return state;
 };
 
-const multReducer: LoopReducerWithDefinedState<ReducedState, ReducedActions> = (
+const multReducer: LoopReducerWithDefinedState<ReducedState, MultiplyAction> = (
   state,
   action
 ) => {
-  if (action.type === 'change') {
+  if (action.type === 'multiply') {
     return { ...state, mult: state.mult * action.value };
   }
   return state;
 };
 
-const change = (value: number): ChangeAction => ({
-  type: 'change',
+const add = (value: number): AddAction => ({
+  type: 'add',
+  value
+});
+
+const multiply = (value: number): MultiplyAction => ({
+  type: 'multiply',
   value
 });
 
 const reducer = reduceReducers(addReducer, multReducer);
 
-const result: Loop<ReducedState> = reducer(undefined, change(5));
-const newState: ReducedState = getModel(result);
-const cmd: CmdType | null = getCmd(result);
+const result1: Loop<ReducedState> = reducer(undefined, add(5));
+const result2: Loop<ReducedState> = reducer(initialState, multiply(5));
+const newState: ReducedState = getModel(result2);
+const cmd: CmdType | null = getCmd(result2);

--- a/test/typescript/reduce-reducers.ts
+++ b/test/typescript/reduce-reducers.ts
@@ -9,6 +9,7 @@ import {
   getCmd,
   CmdType
 } from '../../index';
+import { Action } from 'redux';
 
 type ReducedState = {
   add: number;
@@ -20,10 +21,15 @@ const initialState: ReducedState = {
   mult: 2
 };
 
-type ReducedActions = {
-  type: 'change';
+type ChangeAction = Action<'change'> & {
   value: number;
 };
+
+type StuffAction = Action<'stuff'> & {
+  value: string;
+};
+
+type ReducedActions = ChangeAction | StuffAction;
 
 const addReducer: LoopReducer<ReducedState, ReducedActions> = (
   state = initialState,
@@ -45,7 +51,7 @@ const multReducer: LoopReducerWithDefinedState<ReducedState, ReducedActions> = (
   return state;
 };
 
-const change = (value: number): ReducedActions => ({
+const change = (value: number): ChangeAction => ({
   type: 'change',
   value
 });

--- a/test/typescript/reduce-reducers.ts
+++ b/test/typescript/reduce-reducers.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
+  combineReducers,
   reduceReducers,
   Loop,
   LoopReducer,
@@ -7,37 +9,38 @@ import {
   getCmd,
   CmdType
 } from '../../index';
-import { AnyAction } from 'redux';
 
-type ReducedState = { add: number; mult: number };
+type ReducedState = {
+  add: number;
+  mult: number;
+};
 
 const initialState: ReducedState = {
   add: 0,
   mult: 2
 };
 
-type ReducedActions =
-  | {
-      type: 'change';
-      value: number;
-    };
+type ReducedActions = {
+  type: 'change';
+  value: number;
+};
 
 const addReducer: LoopReducer<ReducedState, ReducedActions> = (
   state = initialState,
-  action: AnyAction
+  action
 ) => {
-  if(action.type === 'change'){
-    return {...state, add: state.add + action.value};
+  if (action.type === 'change') {
+    return { ...state, add: state.add + action.value };
   }
   return state;
 };
 
 const multReducer: LoopReducerWithDefinedState<ReducedState, ReducedActions> = (
   state,
-  action: AnyAction
+  action
 ) => {
-  if(action.type === 'change'){
-    return {...state, mult: state.mult * action.value};
+  if (action.type === 'change') {
+    return { ...state, mult: state.mult * action.value };
   }
   return state;
 };
@@ -49,6 +52,6 @@ const change = (value: number): ReducedActions => ({
 
 const reducer = reduceReducers(addReducer, multReducer);
 
-const result: Loop<ReducedState, ReducedActions> = reducer(undefined, change(5));
+const result: Loop<ReducedState> = reducer(undefined, change(5));
 const newState: ReducedState = getModel(result);
-const cmd: CmdType<ReducedActions> | null = getCmd(result);
+const cmd: CmdType | null = getCmd(result);

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -896,6 +901,11 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
+
+"@types/json-schema@^7.0.3":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/node@*", "@types/node@^12.6.9":
   version "12.7.2"
@@ -925,6 +935,50 @@
   integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.2.0.tgz#7fb997f391af32ae6ca1dbe56bcefe4dd30bda14"
+  integrity sha512-t9RTk/GyYilIXt6BmZurhBzuMT9kLKw3fQoJtK9ayv0tXTlznXEAnx07sCLXdkN3/tZDep1s1CEV95CWuARYWA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "3.2.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.2.0.tgz#4dab8fc9f44f059ec073470a81bb4d7d7d51e6c5"
+  integrity sha512-UbJBsk+xO9dIFKtj16+m42EvUvsjZbbgQ2O5xSTSfVT1Z3yGkL90DVu0Hd3029FZ5/uBgl+F3Vo8FAcEcqc6aQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "3.2.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.2.0.tgz#d9d7867456b1b8ecae9e724269b0bc932f06cbca"
+  integrity sha512-Vhu+wwdevDLVDjK1lIcoD6ZbuOa93fzqszkaO3iCnmrScmKwyW/AGkzc2UvfE5TCoCXqq7Jyt6SOXjsIlpqF4A==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "3.2.0"
+    "@typescript-eslint/typescript-estree" "3.2.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.2.0.tgz#c735f1ca6b4d3cd671f30de8c9bde30843e7ead8"
+  integrity sha512-uh+Y2QO7dxNrdLw7mVnjUqkwO/InxEqwN0wF+Za6eo3coxls9aH9kQ/5rSvW2GcNanebRTmsT5w1/92lAOb1bA==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 JSONStream@~1.3.1:
   version "1.3.5"
@@ -2475,6 +2529,13 @@ eslint-utils@^1.3.1:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
@@ -3163,6 +3224,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, gl
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -6345,6 +6418,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 regexpu-core@^4.5.4:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.5.tgz#aaffe61c2af58269b3e516b61a73790376326411"
@@ -6751,6 +6829,11 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 semver@~5.1.0:
   version "5.1.1"
@@ -7428,10 +7511,22 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+tslib@^1.8.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
As discussed in issue https://github.com/redux-loop/redux-loop/issues/243 actions are not always dispatched from loops. This PR defaults the `Action` generic to `never` in the various spots where an action may not be dispatched.