### PR TITLE
Typescript fixes: export WithDefaultActionHandling, fix generics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,8 +126,8 @@ export namespace Cmd {
   export const dispatch: unique symbol;
   export const getState: unique symbol;
   export const none: NoneCmd;
-  export type Dispatch = <A extends Action>(a: A) => Promise<A>;
-  export type GetState = <S>() => S;
+  export type Dispatch<A extends Action = AnyAction> = (a: A) => Promise<A>;
+  export type GetState<S = any> = () => S;
 
   export function action<A extends Action>(action: A): ActionCmd<A>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface StoreCreator {
   ): Store<S>;
 }
 
-type WithDefaultActionHandling<T extends AnyAction> =
+export type WithDefaultActionHandling<T extends AnyAction> =
   | T
   | Action<'@@REDUX_LOOP/ENFORCE_DEFAULT_HANDLING'>;
 


### PR DESCRIPTION
1. Export `WithDefaultActionHandling`, otherwise it is impossible to explicitly specify a correct type for your reducer's arguments, like so:
   ```
   function reducer(state: State, action: WithDefaultActionHandling<Action>): State | Loop<State> { ... }
   ```
2. Allow specifying the generic types of `Dispatch` and `GetState`.

Both of these changes are fully backwards compatible.  