### PR TITLE
Add `flattenCmd`

### DIFF
--- a/docs/tutorial/Testing.md
+++ b/docs/tutorial/Testing.md
@@ -34,6 +34,49 @@ test('reducer works as expected', (t) => {
 > not equal within JavaScript, and so are best to avoid if you want to compare
 > effects in your tests.
 
+## Working with nested cmd objects
+
+You may need to test objects from the `Cmd` module that make use of
+`Cmd.list` or `Cmd.map`. Imagine in the above example the reducer is updated to
+perform multiple commands when loading starts. We want to test that the properly
+shaped `fetchDetails` cmd is called, but don't necessarily want to mock out every
+effect in `Cmd.list` for an assertion. `flattenCmd` will return all commands nested in
+`Cmd.list`, `Cmd.map`, `Cmd.setInterval` and `Cmd.timeout` in a coniently un-nested array that contains
+only `Cmd.none`, `Cmd.run`, and `Cmd.action` objects.
+
+```js
+import test from 'tape';
+import reducer, { fetchDetails } from './reducer';
+import { loadingStart, loadingSuccess, loadingError } from './actions';
+import { Cmd, loop, flattenCmd, getCmd } from 'redux-loop';
+
+test('reducer fetches data after loadingStart action', (t) => {
+  t.plan(2)
+  const state = { loading: false };
+
+  const resultCmd = getCmd(
+    reducer(state, loadingStart(1));
+  );
+
+  const fetchCmd = flattenCmd(resultCmd).find((cmd) => {
+    return cmd.successActionCreator === loadingSuccess
+  })
+
+  t.ok(fetchCmd)
+
+  t.deepEqual(
+    fetchCmd,
+    Cmd.run(fetchDetails, {
+      successActionCreator: loadingSuccess,
+      failActionCreator: loadingError,
+      args: [1]
+    })
+  )
+
+  t.end()
+});
+```
+
 ## Simulating cmd objects
 
 Occasionally you may find yourself in a situation where you need to pass more
@@ -71,3 +114,11 @@ You can simulate any cmd object to test the actions returned. Lists take
 arrays of simulations for their child cmds.
 
 [See detailed documentation about simulating Cmds](/docs/api-docs/cmds.md)
+
+## Testing nested cmd objects
+
+You may have cases where you are interested in 
+
+```
+
+```

--- a/docs/tutorial/Testing.md
+++ b/docs/tutorial/Testing.md
@@ -41,7 +41,7 @@ You may need to test objects from the `Cmd` module that make use of
 perform multiple commands when loading starts. We want to test that the properly
 shaped `fetchDetails` cmd is called, but don't necessarily want to mock out every
 effect in `Cmd.list` for an assertion. `flattenCmd` will return all commands nested in
-`Cmd.list`, `Cmd.map`, `Cmd.setInterval` and `Cmd.timeout` in a coniently un-nested array that contains
+`Cmd.list`, `Cmd.map`, `Cmd.setInterval` and `Cmd.timeout` in a conveniently un-nested array that contains
 only `Cmd.none`, `Cmd.run`, and `Cmd.action` objects.
 
 ```js
@@ -114,11 +114,3 @@ You can simulate any cmd object to test the actions returned. Lists take
 arrays of simulations for their child cmds.
 
 [See detailed documentation about simulating Cmds](/docs/api-docs/cmds.md)
-
-## Testing nested cmd objects
-
-You may have cases where you are interested in 
-
-```
-
-```

--- a/index.d.ts
+++ b/index.d.ts
@@ -266,3 +266,5 @@ export function isLoop(test: any): boolean;
 export function getModel<S>(loop: S | Loop<S>): S;
 
 export function getCmd(a: any): CmdType | null;
+
+export function flattenCmd(cmd: CmdType): CmdType[];

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -434,6 +434,20 @@ const none = Object.freeze({
   simulate: () => null,
 });
 
+export function flattenCmd(cmd) {
+  if (
+    cmd.type === cmdTypes.MAP ||
+    cmd.type === cmdTypes.SET_TIMEOUT ||
+    cmd.type === cmdTypes.SET_INTERVAL
+  ) {
+    return flattenCmd(cmd.nestedCmd);
+  }
+  if (cmd.type === cmdTypes.LIST) {
+    return cmd.cmds.flatMap(flattenCmd);
+  }
+  return [cmd];
+}
+
 export default {
   run,
   action,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { loop, liftState, getModel, getCmd, isLoop } from './loop';
 
-import Cmd from './cmd';
+import Cmd, { flattenCmd } from './cmd';
 
 import { install } from './install';
 
@@ -27,4 +27,4 @@ export function reduceReducers(...args) {
   return r(...args);
 }
 
-export { Cmd, install, loop, liftState, getModel, getCmd, isLoop };
+export { Cmd, install, loop, liftState, getModel, getCmd, isLoop, flattenCmd };


### PR DESCRIPTION
[Motivated by the discussion here](https://github.com/redux-loop/redux-loop/issues/252), we have an application making extensive use of `redux-loop`'s `Cmd.map` and `Cmd.list` functionality to support sub-modules (very similar to how Elm apps are traditionally structured) and want to test commands in a convenient way.

[Example fork used is published here](https://www.npmjs.com/package/@abradley2/redux-loop). In our tests we had a dozen situations where we used a similar `getRunCmd` function that did much of the logic in `flattenCmd` and then did a `.find`

Implementing that function now looks something like:
```
import { flattenCmd, CmdType, RunCmd } from '@abradley2/redux-loop'

export const getRunCmd = (cmd, func) => flattenCmd(cmd).find((c) => c.type === 'RUN' && c.func === func)
```